### PR TITLE
Implement inline svg component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
                 "react-dom": "^18.3.1",
                 "react-github-btn": "^1.4.0",
                 "react-imask": "^7.6.1",
+                "react-inlinesvg": "^4.1.4",
                 "react-scripts": "5.0.1",
                 "web-vitals": "^2.1.4"
             },
@@ -13265,6 +13266,14 @@
             "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
             "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
         },
+        "node_modules/react-from-dom": {
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/react-from-dom/-/react-from-dom-0.7.3.tgz",
+            "integrity": "sha512-9IK6R7+eD1wOAMC2ZCrENev0eK1625cb7vX+cnnOR9LBRNbjKiaJk4ij2zQbcefEXTWjXFhA7CTO1cd8wMONnw==",
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            }
+        },
         "node_modules/react-github-btn": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/react-github-btn/-/react-github-btn-1.4.0.tgz",
@@ -13289,6 +13298,17 @@
             },
             "peerDependencies": {
                 "react": ">=0.14.0"
+            }
+        },
+        "node_modules/react-inlinesvg": {
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/react-inlinesvg/-/react-inlinesvg-4.1.4.tgz",
+            "integrity": "sha512-V7x3YGqG7LNeHpsIx90HDa2qhYCOPkzjIMToPWALyvOTI3kzicKF2O2PNZDaVqAVhwRbijLIUoQN5STleTO2rg==",
+            "dependencies": {
+                "react-from-dom": "^0.7.3"
+            },
+            "peerDependencies": {
+                "react": "16.8 - 18"
             }
         },
         "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
         "react-dom": "^18.3.1",
         "react-github-btn": "^1.4.0",
         "react-imask": "^7.6.1",
+        "react-inlinesvg": "^4.1.4",
         "react-scripts": "5.0.1",
         "web-vitals": "^2.1.4"
     },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,8 +5,10 @@ import { utils } from "./utils/";
 import "./index.css";
 import GitHubButton from "react-github-btn";
 import ThemeToggle from "./components/DarkmodeToggle";
+import SVG from "react-inlinesvg";
 
 const App = () => {
+    const SVGComponent = SVG as React.FC<any>;
     const formOnSubmitHandler = (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault();
         if (typeof layoutOption !== "undefined") {
@@ -548,10 +550,7 @@ const App = () => {
                     </a>
                 </footer>
             </form>
-            <div
-                className="column-pane right"
-                dangerouslySetInnerHTML={{ __html: drawingSVG.outerHTML }}
-            />
+            <SVGComponent className="column-pane right" src={drawingSVG.outerHTML} />
         </div>
     );
 };


### PR DESCRIPTION
Added ```react-inlinesvg``` as a dependency to enable loading in the SVG as a component and to avoid using ```dangerouslySetInnerHTML```