### PR TITLE
Refactored with modularisation of page elements and logic

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState, useEffect, useRef } from "react";
+import React, { useRef } from "react";
 import GitHubButton from "react-github-btn";
 import { IMaskInput } from "react-imask";
 import {
@@ -14,22 +14,10 @@ import { ReactComponent as StarIcon } from "./assets/star.svg";
 import { ReactComponent as GridIcon } from "./assets/grid-icon.svg";
 import { ReactComponent as SaveIcon } from "./assets/save-icon.svg";
 import { ReactComponent as CopyIcon } from "./assets/copy-icon.svg";
-import "./index.css";
-
-type LayoutResults = {
-    30: (ITubeSheetData & { preferred: boolean }) | null;
-    45: (ITubeSheetData & { preferred: boolean }) | null;
-    60: (ITubeSheetData & { preferred: boolean }) | null;
-    90: (ITubeSheetData & { preferred: boolean }) | null;
-    radial: (ITubeSheetData & { preferred: boolean }) | null;
-};
-
-interface Position {
-    x: number;
-    y: number;
-}
-
-type AnimationLifecycle = "idle" | "fading-in" | "fading-out";
+import { useTubeSheetWorker, LayoutResults } from "./hooks/useTubeSheetWorker";
+import { useLayoutForm } from "./hooks/useLayoutForm";
+import { useSvgExportActions } from "./hooks/useSvgExportActions";
+import { useContextMenu } from "./hooks/useContextMenu";
 
 const emptyTubeSheet = new TubeSheet(0, 100, 1, 30, undefined, 100);
 const emptyData: ITubeSheetData = {
@@ -44,664 +32,70 @@ const emptyData: ITubeSheetData = {
 };
 const placeholderSVG = generateTubeSheetSVG(emptyData);
 
-const downloadBlob = (blob: Blob | MediaSource, filename: string) => {
-    const objectUrl = URL.createObjectURL(blob);
-
-    const link = document.createElement("a");
-    link.href = objectUrl;
-    link.download = filename;
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-
-    setTimeout(() => URL.revokeObjectURL(objectUrl), 5000);
-};
-
-// Clone svg with explicit pixel dimensions derived from viewBox
-// for SVG and PNG rasterisation.
-const sizedSvgString = (svg: SVGSVGElement, scale = 2) => {
-    const viewBox = svg.getAttribute("viewBox");
-    const parts = viewBox ? viewBox.split(" ").map(Number) : [0, 0, 300, 150];
-    const vbWidth = parts[2] || 300;
-    const vbHeight = parts[3] || 300;
-    const width = Math.max(1, Math.round(vbWidth * scale));
-    const height = Math.max(1, Math.round(vbHeight * scale));
-
-    const clone = svg.cloneNode(true) as SVGSVGElement;
-    clone.setAttribute("width", `${width}`);
-    clone.setAttribute("height", `${height}`);
-    clone.setAttribute("xmlns", "http://www.w3.org/2000/svg");
-
-    return { svgString: new XMLSerializer().serializeToString(clone), width, height };
-};
-
-// Rasterise SVG to a PNG blob.
-const svgToPngBlob = (svg: SVGSVGElement, scale = 2): Promise<Blob> => {
-    return new Promise((resolve, reject) => {
-        const { svgString, width, height } = sizedSvgString(svg, scale);
-        const svgBlob = new Blob([svgString], { type: "image/svg+xml;charset=utf-8" });
-        const url = URL.createObjectURL(svgBlob);
-
-        const image = new Image();
-        image.onload = () => {
-            const canvas = document.createElement("canvas");
-            canvas.width = width;
-            canvas.height = height;
-            const ctx = canvas.getContext("2d");
-            URL.revokeObjectURL(url);
-            if (!ctx) {
-                reject(new Error("Canvas 2D context unavailable"));
-                return;
-            }
-            ctx.drawImage(image, 0, 0, width, height);
-            canvas.toBlob((blob) => {
-                if (blob) {
-                    resolve(blob);
-                } else {
-                    reject(new Error("Failed to encode PNG"));
-                }
-            }, "image/png");
-        };
-        image.onerror = () => {
-            URL.revokeObjectURL(url);
-            reject(new Error("Failed to load SVG for rasterisation"));
-        };
-        image.src = url;
-    });
-};
+// Layout options for displaying min ID and tube counts.
+const layoutOptionRows: {
+    key: keyof LayoutResults;
+    id: string;
+    label: string;
+    value: string;
+    required?: boolean;
+}[] = [
+    { key: 30, id: "30deg", label: "30°", value: "30", required: true },
+    { key: 45, id: "45deg", label: "45°", value: "45" },
+    { key: 60, id: "60deg", label: "60°", value: "60" },
+    { key: 90, id: "90deg", label: "90°", value: "90" },
+    { key: "radial", id: "radial", label: "Radial", value: "0" },
+];
 
 const App = () => {
-    // Layout data states
-    const [minTubes, setMinTubes] = useState<number | undefined>();
-    const [tubeOD, setTubeOD] = useState<number | undefined>();
-    const [OTLtoShell, setOTLtoShell] = useState<number | undefined>();
-    const [tubeClearance, setTubeClearance] = useState<number | undefined>();
-    const [pitchRatio, setPitchRatio] = useState<number | undefined>();
-    const [shellID, setShellID] = useState<number | undefined>();
-    const [actualTubes, setActualTubes] = useState<number | undefined>();
-    const [layoutOption, setLayoutOption] = useState<number | undefined>();
-    const [pitchUpdateFunc, setPitchUpdateFunc] = useState<string | undefined>();
-    const [layoutResults, setLayoutResults] = useState<LayoutResults>({
-        "30": null,
-        "45": null,
-        "60": null,
-        "90": null,
-        radial: null,
-    });
-    const [layoutInputsDefined, setLayoutInputsDefined] = useState<boolean>(false);
-    const [layoutOptionSelected, setLayoutOptionSelected] = useState<boolean>(false);
-    const [drawingSVG, setDrawingSVG] = useState<SVGSVGElement>(placeholderSVG);
-
-    // Copy state
-    const [copyState, setCopyState] = useState<"idle" | "copied" | "error" | "unsupported">("idle");
-
-    // Show/hide grid state
-    const [showGrid, setShowGrid] = useState<boolean>(true);
-
-    // Loading/calculation visual states
-    const [isCalculating, setIsCalculating] = useState<boolean>(false);
-    const [showLoadingBadge, setShowLoadingBadge] = useState<boolean>(false);
-    const loadingShownAtRef = useRef<number | null>(null);
-    const [calcError, setCalcError] = useState<string | null>(null);
-
-    // Context menu
-    const [contextMenuPos, setContextMenuPos] = useState<Position>({ x: 0, y: 0 });
-    const containerRef = useRef<HTMLDivElement>(null);
-    const [contextMenuAnimationState, setContextMenuAnimationState] =
-        useState<AnimationLifecycle>("idle");
-
-    // Screen-reader-only status state
-    const [announcement, setAnnouncement] = useState<string>("");
-
-    // Refs
-    const hasRenderedOnceRef = useRef(false);
-    // Track outstanding calculations so "isCalculating" clears only when all finish.
-    const pendingCompletionsRef = useRef(0);
-    // Worker responses increment these refs synchronously; effects drain them.
-    const pendingAllResponsesRef = useRef(0);
-    const pendingSingleResponsesRef = useRef(0);
-    const beginCalculation = () => {
-        pendingCompletionsRef.current += 1;
-        setCalcError(null);
-        setIsCalculating(true);
-    };
-    const completeCalculation = () => {
-        pendingCompletionsRef.current = Math.max(0, pendingCompletionsRef.current - 1);
-        if (pendingCompletionsRef.current === 0) {
-            setIsCalculating(false);
-        }
-    };
-    // Drain counter and call completeCalculation per recorded response.
-    const drainCompletions = useCallback((counterRef: { current: number }) => {
-        const count = counterRef.current;
-        counterRef.current = 0;
-        for (let i = 0; i < count; i++) {
-            completeCalculation();
-        }
-    }, []);
-    // Workers
-    const [workerInstance, setWorkerInstance] = useState<Worker | null>(null);
-
-    const stateFuncs = {
-        setMinTubes,
-        setTubeOD,
-        setOTLtoShell,
-        setTubeClearance,
-        setPitchRatio,
-        setShellID,
-        setActualTubes,
-        setLayoutOption,
-    };
-
-    useEffect(() => {
-        const w = new Worker(new URL("./workers/tubesheet.worker.ts", import.meta.url));
-
-        w.onmessage = (event) => {
-            const { type, payload } = event.data;
-
-            if (type === "ALL_RESULTS") {
-                // Count ALL_RESULTS now; an effect will drain and clear isCalculating.
-                pendingAllResponsesRef.current += 1;
-                setLayoutResults(payload);
-            }
-
-            if (type === "SINGLE_RESULT") {
-                // Count SINGLE_RESULT and set SVG; TubeSheetSVG's onRendered clears isCalculating.
-                pendingSingleResponsesRef.current += 1;
-                setCalcError(null);
-                setDrawingSVG(generateTubeSheetSVG(payload));
-
-                // If shellID was custom inputted, update actual tubes
-                if (payload.shellID && payload.numTubes) {
-                    setActualTubes(payload.numTubes);
-                }
-            }
-
-            if (type === "ERROR") {
-                console.error("Worker Error:", payload);
-                setCalcError(typeof payload === "string" ? payload : "Calculation failed.");
-                setAnnouncement(`Calculation failed: ${payload}`);
-                // On ERROR: reset counters, show error, and stop loading.
-                pendingCompletionsRef.current = 0;
-                pendingAllResponsesRef.current = 0;
-                pendingSingleResponsesRef.current = 0;
-                setIsCalculating(false);
-                loadingShownAtRef.current = null;
-                setShowLoadingBadge(false);
-            }
-        };
-
-        setWorkerInstance(w);
-
-        return () => {
-            w.terminate();
-        };
-    }, []);
-
-    // Debounce showing the loading badge.
-    useEffect(() => {
-        const SHOW_DELAY_MS = 150;
-        const MIN_VISIBLE_MS = 300;
-
-        if (isCalculating) {
-            setAnnouncement("Calculating layout…");
-
-            const showTimer = window.setTimeout(() => {
-                loadingShownAtRef.current = Date.now();
-                setShowLoadingBadge(true);
-            }, SHOW_DELAY_MS);
-
-            return () => clearTimeout(showTimer);
-        }
-
-        // Calculation finished. If the badge never actually became visible
-        // the cleanup above already cancelled the timer.
-        if (loadingShownAtRef.current === null) {
-            return;
-        }
-
-        const elapsed = Date.now() - loadingShownAtRef.current;
-        const remaining = Math.max(0, MIN_VISIBLE_MS - elapsed);
-
-        const hideTimer = window.setTimeout(() => {
-            setShowLoadingBadge(false);
-            loadingShownAtRef.current = null;
-        }, remaining);
-
-        return () => clearTimeout(hideTimer);
-    }, [isCalculating]);
-
-    // After layoutResults commit: drain pending ALL_RESULTS count.
-    useEffect(() => {
-        drainCompletions(pendingAllResponsesRef);
-    }, [layoutResults, drainCompletions]);
-
-    // Stable callback for TubeSheetSVG render.
-    const onDrawingRendered = useCallback(() => {
-        // Drain pending SINGLE_RESULT count.
-        drainCompletions(pendingSingleResponsesRef);
-
-        // Skip initial placeholder announcement
-        if (!hasRenderedOnceRef.current) {
-            hasRenderedOnceRef.current = true;
-            return;
-        }
-
-        setAnnouncement("Layout updated.");
-    }, [drainCompletions]);
-
-    // Helper to package and send calculation requests
-    const triggerSingleCalculation = (overrides?: {
-        overrideLayout?: number;
-        OTLtoShell?: number;
-        tubeOD?: number;
-        pitchRatio?: number;
-        minTubes?: number;
-        shellID?: number;
-    }) => {
-        if (!workerInstance) return;
-
-        const effOTLtoShell = overrides?.OTLtoShell ?? OTLtoShell;
-        const effTubeOD = overrides?.tubeOD ?? tubeOD;
-        const effPitchRatio = overrides?.pitchRatio ?? pitchRatio;
-        const effMinTubes = overrides?.minTubes ?? minTubes;
-        const effShellID = overrides?.shellID ?? shellID;
-        const effLayoutOption = overrides?.overrideLayout ?? layoutOption;
-
-        const parsedLayoutOption = effLayoutOption === 0 ? "radial" : effLayoutOption;
-
-        beginCalculation();
-        workerInstance.postMessage({
-            type: "CALCULATE_SINGLE",
-            payload: {
-                OTLtoShell: effOTLtoShell,
-                tubeOD: effTubeOD,
-                pitchRatio: effPitchRatio,
-                layoutOption: parsedLayoutOption,
-                minTubes: utils.isNumber(effShellID) && effShellID !== 0 ? undefined : effMinTubes,
-                shellID: utils.isNumber(effShellID) && effShellID !== 0 ? effShellID : undefined,
-            },
-        });
-    };
-
-    const formOnSubmitHandler = (e: React.FormEvent<HTMLFormElement>) => {
-        e.preventDefault();
-        // Fallback: If form submits, trigger a single calc request
-        if (utils.isNumber(layoutOption) && layoutInputsDefined) {
-            triggerSingleCalculation();
-        }
-    };
-
-    const validateLayoutOption = useCallback(() => {
-        const valid = utils.isNumber(layoutOption);
-        setLayoutOptionSelected(valid);
-        // console.log(`Layout option validated: ${valid}`);
-    }, [layoutOption]);
-
-    const validateLayoutInputs = useCallback(() => {
-        const valid =
-            utils.isNumber(OTLtoShell) &&
-            utils.isNumber(tubeOD) &&
-            utils.isNumber(tubeClearance) &&
-            utils.isNumber(pitchRatio) &&
-            utils.isNumber(minTubes) &&
-            OTLtoShell >= 0 &&
-            tubeOD > 0 &&
-            tubeClearance >= 0 &&
-            pitchRatio >= 1 &&
-            minTubes > 0;
-        setLayoutInputsDefined(valid);
-        // console.log(`Layout calc inputs validated: ${valid}`);
-    }, [OTLtoShell, minTubes, pitchRatio, tubeClearance, tubeOD]);
-
-    const requestAllLayoutResults = useCallback(() => {
-        if (!layoutInputsDefined || !workerInstance) return;
-
-        beginCalculation();
-        workerInstance.postMessage({
-            type: "CALCULATE_ALL",
-            payload: { OTLtoShell, tubeOD, pitchRatio, minTubes },
-        });
-    }, [layoutInputsDefined, workerInstance, OTLtoShell, tubeOD, pitchRatio, minTubes]);
-
-    const callSetFunc = (name: string, value: string) => {
-        if (!(name in stateFuncs)) {
-            console.error(`Function ${name} not found.`);
-            return;
-        }
-
-        const fn = stateFuncs[name as keyof typeof stateFuncs];
-
-        if (!utils.isNumber(value)) {
-            fn(undefined);
-            return;
-        } else {
-            fn(utils.stringToNumber(value));
-        }
-    };
-
-    const setPitchRatioFromTubeClearance = useCallback(
-        (value: number) => {
-            if (utils.isNumber(value) && utils.isNumber(tubeOD) && tubeOD > 0) {
-                setPitchRatio(1 + value / tubeOD);
-            }
-        },
-        [tubeOD],
-    );
-
-    const setTubeClearanceFromPitchRatio = useCallback(
-        (value: number) => {
-            if (utils.isNumber(value) && utils.isNumber(tubeOD)) {
-                setTubeClearance((value - 1) * tubeOD);
-            }
-        },
-        [tubeOD],
-    );
-
-    // Allow empty values via onAccept to avoid IMask reverting them.
-    const onAcceptEmpty = (value: string, name: string) => {
-        if (value.trim() === "") {
-            callSetFunc(`set${utils.capitalize(name)}`, "");
-        }
-    };
-
-    const onBlur = (e: React.SyntheticEvent<HTMLInputElement>) => {
-        const val = e.currentTarget.value.replace(",", ""),
-            name = e.currentTarget.name;
-
-        // An intentionally emptied field should stay empty rather than bounce
-        // back to its last committed value.
-        if (val.trim() === "") {
-            callSetFunc(`set${utils.capitalize(name)}`, val);
-            return;
-        }
-
-        if (!utils.isNumber(val)) {
-            return;
-        }
-        switch (name) {
-            case "tubeClearance":
-                if (!utils.isNumber(tubeClearance) || tubeClearance <= 0) {
-                    callSetFunc(`set${utils.capitalize(name)}`, val);
-                    setPitchUpdateFunc("setPitchRatioFromTubeClearance");
-                    setPitchRatioFromTubeClearance(parseFloat(val));
-                    break;
-                }
-                if (utils.trunc(tubeClearance, 2) !== utils.stringToNumber(val)) {
-                    callSetFunc(`set${utils.capitalize(name)}`, val);
-                    setPitchUpdateFunc("setPitchRatioFromTubeClearance");
-                    break;
-                }
-                break;
-
-            case "pitchRatio":
-                if (!utils.isNumber(pitchRatio) || pitchRatio <= 0) {
-                    callSetFunc(`set${utils.capitalize(name)}`, val);
-                    setPitchUpdateFunc("setTubeClearanceFromPitchRatio");
-                    setTubeClearanceFromPitchRatio(parseFloat(val));
-                    break;
-                }
-                if (utils.trunc(pitchRatio, 2) !== utils.stringToNumber(val)) {
-                    callSetFunc(`set${utils.capitalize(name)}`, val);
-                    setPitchUpdateFunc("setTubeClearanceFromPitchRatio");
-                    break;
-                }
-                break;
-            default:
-                callSetFunc(`set${utils.capitalize(name)}`, val);
-        }
-    };
-
-    const inputOnSubmitHandler = (e: React.SubmitEvent<HTMLInputElement>) => {
-        e.preventDefault();
-    };
-
-    // Handle Enter/Tab: commit field and trigger calc with snapshot.
-    const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-        if (e.key !== "Enter" && e.key !== "NumpadEnter" && e.key !== "Tab") {
-            return;
-        }
-
-        if (e.key === "Enter" || e.key === "NumpadEnter") {
-            e.preventDefault();
-        }
-
-        const name = e.currentTarget.name;
-        const raw = e.currentTarget.value.replace(",", "");
-        const committed = utils.isNumber(raw) ? utils.stringToNumber(raw) : undefined;
-
-        const currentValues: Record<string, number | undefined> = {
-            minTubes,
-            tubeOD,
-            OTLtoShell,
-            tubeClearance,
-            pitchRatio,
-            shellID,
-        };
-
-        const currentValue = currentValues[name];
-        const unchanged = (() => {
-            // For "tubeClearance" and "pitchRatio", compare values at
-            // display precision (2 decimals).
-            if (name === "tubeClearance" || name === "pitchRatio") {
-                if (utils.isNumber(committed) && utils.isNumber(currentValue)) {
-                    return utils.trunc(currentValue, 2) === utils.trunc(committed, 2);
-                }
-                return committed === currentValue;
-            }
-            return committed === currentValue;
-        })();
-
-        if (unchanged) {
-            onBlur(e);
-            return;
-        }
-
-        onBlur(e);
-
-        let nextPitchRatio = name === "pitchRatio" ? committed : pitchRatio;
-        let nextTubeClearance = name === "tubeClearance" ? committed : tubeClearance;
-        if (
-            name === "tubeClearance" &&
-            utils.isNumber(committed) &&
-            utils.isNumber(tubeOD) &&
-            tubeOD > 0
-        ) {
-            nextPitchRatio = 1 + committed / tubeOD;
-        } else if (name === "pitchRatio" && utils.isNumber(committed) && utils.isNumber(tubeOD)) {
-            nextTubeClearance = (committed - 1) * tubeOD;
-        }
-
-        // Nothing to recalculate if this field's value is unchanged.
-        const next = {
-            minTubes: name === "minTubes" ? committed : minTubes,
-            tubeOD: name === "tubeOD" ? committed : tubeOD,
-            OTLtoShell: name === "OTLtoShell" ? committed : OTLtoShell,
-            tubeClearance: nextTubeClearance,
-            pitchRatio: nextPitchRatio,
-            shellID: name === "shellID" ? committed : shellID,
-        };
-
-        const inputsValid =
-            utils.isNumber(next.OTLtoShell) &&
-            utils.isNumber(next.tubeOD) &&
-            utils.isNumber(next.tubeClearance) &&
-            utils.isNumber(next.pitchRatio) &&
-            utils.isNumber(next.minTubes) &&
-            next.OTLtoShell >= 0 &&
-            next.tubeOD > 0 &&
-            next.tubeClearance >= 0 &&
-            next.pitchRatio >= 1 &&
-            next.minTubes > 0;
-
-        if (!inputsValid || !utils.isNumber(layoutOption)) {
-            return;
-        }
-
-        triggerSingleCalculation({
-            OTLtoShell: next.OTLtoShell,
-            tubeOD: next.tubeOD,
-            pitchRatio: next.pitchRatio,
-            minTubes: next.minTubes,
-            shellID: next.shellID,
-        });
-    };
-
-    // Regenerate on layout option change and inputs are valid.
-    const onLayoutOptionChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-        onBlur(e);
-
-        const rawValue = e.currentTarget.value;
-        const parsedValue = utils.isNumber(rawValue) ? utils.stringToNumber(rawValue) : undefined;
-
-        if (!utils.isNumber(parsedValue) || !layoutInputsDefined) {
-            return;
-        }
-
-        triggerSingleCalculation({ overrideLayout: parsedValue });
-    };
-
-    const downloadSVG = useCallback(() => {
-        const blob = new Blob([drawingSVG.outerHTML], { type: "image/svg+xml" });
-        downloadBlob(blob, "tubesheet.svg");
-    }, [drawingSVG.outerHTML]);
-
-    const copySVG = useCallback(() => {
-        if (
-            typeof navigator === "undefined" ||
-            !navigator.clipboard ||
-            typeof ClipboardItem === "undefined"
-        ) {
-            setCopyState("unsupported");
-            return;
-        }
-
-        // Clipboard writes must occur during user activation. Pass pending
-        // Promises to "ClipboardItem" so browsers accept async image data.
-        const { svgString } = sizedSvgString(drawingSVG);
-        const svgBlob = new Blob([svgString], { type: "image/svg+xml;charset=utf-8" });
-        const pngPromise = svgToPngBlob(drawingSVG);
-
-        const onSuccess = () => {
-            setCopyState("copied");
-            setTimeout(() => setCopyState("idle"), 2000);
-        };
-        const onFailure = (err: unknown) => {
-            console.error("Copy to clipboard failed:", err);
-            setCopyState("error");
-            setTimeout(() => setCopyState("idle"), 2500);
-        };
-
-        // SVG with PNG fallback.
-        let writePromise: Promise<void>;
-        try {
-            writePromise = navigator.clipboard.write([
-                new ClipboardItem({ "image/svg+xml": svgBlob, "image/png": pngPromise }),
-            ]);
-        } catch {
-            writePromise = Promise.reject();
-        }
-
-        writePromise.then(onSuccess).catch(() =>
-            navigator.clipboard
-                .write([new ClipboardItem({ "image/png": pngPromise })])
-                .then(onSuccess)
-                .catch(onFailure),
-        );
-    }, [drawingSVG]);
-
-    // Validation
-    useEffect(() => {
-        // console.log("calling validateLayoutInputs");
-        validateLayoutInputs();
-        // console.log("calling validateLayoutOption");
-        validateLayoutOption();
-    }, [validateLayoutInputs, validateLayoutOption]);
-
-    // Pitch calculation
-    useEffect(() => {
-        if (typeof pitchUpdateFunc !== "undefined") {
-            let value = tubeClearance;
-            switch (pitchUpdateFunc) {
-                case "setPitchRatioFromTubeClearance":
-                    value = tubeClearance;
-                    if (utils.isNumber(value)) {
-                        // console.log("setting pitch ratio from tube clearance");
-                        setPitchRatioFromTubeClearance(value);
-                    }
-                    break;
-                case "setTubeClearanceFromPitchRatio":
-                    value = pitchRatio;
-                    if (utils.isNumber(value)) {
-                        // console.log("setting tube clearance from pitch ratio");
-                        setTubeClearanceFromPitchRatio(value);
-                    }
-                    break;
-            }
-            // console.log("calling requestAllLayoutResults");
-            if (layoutInputsDefined) {
-                requestAllLayoutResults();
-            }
-        }
-    }, [
+    // Worker lifecycle, calculation results, loading/error/status state.
+    const {
+        layoutResults,
+        drawingSVG,
+        lastSingleResult,
+        isCalculating,
+        showLoadingBadge,
+        calcError,
+        announcement,
+        onDrawingRendered,
+        postCalculateSingle,
+        postCalculateAll,
+    } = useTubeSheetWorker(placeholderSVG);
+
+    // All calculation-input field state, validation, and input handlers.
+    const {
+        minTubes,
+        tubeOD,
+        OTLtoShell,
         tubeClearance,
         pitchRatio,
-        tubeOD,
-        pitchUpdateFunc,
+        shellID,
+        actualTubes,
         layoutInputsDefined,
-        setPitchRatioFromTubeClearance,
-        setTubeClearanceFromPitchRatio,
-        requestAllLayoutResults,
-    ]);
+        layoutOptionSelected,
+        onAcceptEmpty,
+        onBlur,
+        onKeyDown,
+        onLayoutOptionChange,
+        formOnSubmitHandler,
+        inputOnSubmitHandler,
+    } = useLayoutForm({ lastSingleResult, postCalculateSingle, postCalculateAll });
 
-    // Actual tubes calculation only when layout option is selected and shell ID is defined
-    useEffect(() => {
-        if (!utils.isNumber(layoutOption)) {
-            // console.log("Layout option not yet selected.");
-            return;
-        }
+    // Copy-to-clipboard / download-as-file actions for the drawing.
+    const { copyState, downloadSVG, copySVG } = useSvgExportActions(drawingSVG);
 
-        let selectedLayout: TubeSheet | null = null;
+    // Show/hide grid state
+    const [showGrid, setShowGrid] = React.useState<boolean>(true);
 
-        const parsedLayoutOption = (
-            layoutOption === 0 ? "radial" : layoutOption
-        ) as TubeSheet["layout"];
-
-        if (utils.isNumber(shellID) && shellID > 0) {
-            selectedLayout = layoutInputsDefined
-                ? new TubeSheet(
-                      OTLtoShell!,
-                      tubeOD!,
-                      pitchRatio!,
-                      parsedLayoutOption,
-                      undefined,
-                      shellID,
-                  )
-                : null;
-        }
-
-        if (selectedLayout && selectedLayout.numTubes) {
-            setActualTubes(selectedLayout.numTubes);
-        }
-    }, [OTLtoShell, layoutInputsDefined, layoutOption, pitchRatio, shellID, tubeOD]);
-
-    // Force refresh when actual tubes are calculated
-    useEffect(() => {}, [actualTubes]);
-
-    // Layout options for displaying min ID and tube counts.
-    const layoutOptionRows: {
-        key: keyof LayoutResults;
-        id: string;
-        label: string;
-        value: string;
-        required?: boolean;
-    }[] = [
-        { key: 30, id: "30deg", label: "30°", value: "30", required: true },
-        { key: 45, id: "45deg", label: "45°", value: "45" },
-        { key: 60, id: "60deg", label: "60°", value: "60" },
-        { key: 90, id: "90deg", label: "90°", value: "90" },
-        { key: "radial", id: "radial", label: "Radial", value: "0" },
-    ];
+    // Context menu
+    const containerRef = useRef<HTMLDivElement>(null);
+    const {
+        contextMenuPos,
+        contextMenuAnimationState,
+        openContextMenu,
+        requestClose,
+        onAnimationEnd,
+    } = useContextMenu(containerRef);
 
     const definedMinIDs = layoutOptionRows
         .map((row) => layoutResults[row.key]?.minID)
@@ -723,46 +117,19 @@ const App = () => {
         return Math.max(12, 12 + logRatio * 88);
     };
 
-    useEffect(() => {
-        const handleContextMenuCloseTrigger = () => {
-            if (contextMenuAnimationState === "fading-in") {
-                setContextMenuAnimationState("fading-out");
-            }
-        };
-        const handleEscapeKey = (e: KeyboardEvent) => {
-            if (e.key === "Escape") handleContextMenuCloseTrigger();
-        };
-        window.addEventListener("click", handleContextMenuCloseTrigger);
-        window.addEventListener("keydown", handleEscapeKey);
-        return () => {
-            window.removeEventListener("click", handleContextMenuCloseTrigger);
-            window.removeEventListener("keydown", handleEscapeKey);
-        };
-    }, [contextMenuAnimationState]);
     const handleContextMenuCopyAction = () => {
         copySVG();
-        setContextMenuAnimationState("fading-out"); // Initiates the safe unmount fade out
+        requestClose(); // Initiates the safe unmount fade out
     };
     const handleContextMenuSaveAction = () => {
         downloadSVG();
-        setContextMenuAnimationState("fading-out"); // Initiates the safe unmount fade out
+        requestClose(); // Initiates the safe unmount fade out
     };
     const menuConfig: ContextMenuItem[] = [
         { label: "Copy Image", icon: <CopyIcon />, onClick: () => handleContextMenuCopyAction() },
         { label: "", isDivider: true, onClick: () => {} },
         { label: "Save Image", icon: <SaveIcon />, onClick: () => handleContextMenuSaveAction() },
     ];
-    const handleContextMenu = (e: React.MouseEvent<HTMLDivElement>) => {
-        e.preventDefault();
-        if (!containerRef.current) return;
-
-        const rect = containerRef.current.getBoundingClientRect();
-        const relativeX = e.clientX - rect.left;
-        const relativeY = e.clientY - rect.top;
-
-        setContextMenuPos({ x: relativeX, y: relativeY });
-        setContextMenuAnimationState("fading-in");
-    };
 
     // JSX return
     return (
@@ -1134,7 +501,7 @@ const App = () => {
                 <div
                     className={`viewport ${showGrid ? "" : "grid-hidden"}`}
                     ref={containerRef}
-                    onContextMenu={handleContextMenu}
+                    onContextMenu={openContextMenu}
                 >
                     {contextMenuAnimationState !== "idle" && (
                         <ContextMenu
@@ -1146,8 +513,8 @@ const App = () => {
                                     ? "fading-in"
                                     : "fading-out"
                             }
-                            onAnimationEnd={() => setContextMenuAnimationState("idle")}
-                            onRequestClose={() => setContextMenuAnimationState("fading-out")}
+                            onAnimationEnd={onAnimationEnd}
+                            onRequestClose={requestClose}
                         />
                     )}
                     <span className="viewport-label noselect">Layout Preview</span>

--- a/src/hooks/useContextMenu.ts
+++ b/src/hooks/useContextMenu.ts
@@ -1,0 +1,55 @@
+import { useEffect, useState } from "react";
+import type { MouseEvent, RefObject } from "react";
+
+interface Position {
+    x: number;
+    y: number;
+}
+
+export type AnimationLifecycle = "idle" | "fading-in" | "fading-out";
+
+// Position, open/close and fade lifecycle for the custom right-click
+// context menu shown over the drawing viewport.
+export function useContextMenu(containerRef: RefObject<HTMLDivElement | null>) {
+    const [contextMenuPos, setContextMenuPos] = useState<Position>({ x: 0, y: 0 });
+    const [contextMenuAnimationState, setContextMenuAnimationState] =
+        useState<AnimationLifecycle>("idle");
+
+    // Close the menu on an outside click or Escape while it's open.
+    useEffect(() => {
+        const handleContextMenuCloseTrigger = () => {
+            if (contextMenuAnimationState === "fading-in") {
+                setContextMenuAnimationState("fading-out");
+            }
+        };
+        const handleEscapeKey = (e: KeyboardEvent) => {
+            if (e.key === "Escape") handleContextMenuCloseTrigger();
+        };
+        window.addEventListener("click", handleContextMenuCloseTrigger);
+        window.addEventListener("keydown", handleEscapeKey);
+        return () => {
+            window.removeEventListener("click", handleContextMenuCloseTrigger);
+            window.removeEventListener("keydown", handleEscapeKey);
+        };
+    }, [contextMenuAnimationState]);
+
+    const openContextMenu = (e: MouseEvent<HTMLDivElement>) => {
+        e.preventDefault();
+        if (!containerRef.current) return;
+
+        const rect = containerRef.current.getBoundingClientRect();
+        setContextMenuPos({ x: e.clientX - rect.left, y: e.clientY - rect.top });
+        setContextMenuAnimationState("fading-in");
+    };
+
+    const requestClose = () => setContextMenuAnimationState("fading-out");
+    const onAnimationEnd = () => setContextMenuAnimationState("idle");
+
+    return {
+        contextMenuPos,
+        contextMenuAnimationState,
+        openContextMenu,
+        requestClose,
+        onAnimationEnd,
+    };
+}

--- a/src/hooks/useLayoutForm.ts
+++ b/src/hooks/useLayoutForm.ts
@@ -1,0 +1,462 @@
+import { useCallback, useEffect, useReducer, useState } from "react";
+import type React from "react";
+import type { ChangeEvent, FormEvent, KeyboardEvent, SyntheticEvent } from "react";
+import { TubeSheet } from "../plugins/tubesheet-layout-generator";
+import { utils } from "../utils/";
+import type { SingleResultPayload } from "./useTubeSheetWorker";
+
+interface UseLayoutFormOptions {
+    lastSingleResult: SingleResultPayload;
+    postCalculateSingle: (payload: Record<string, unknown>) => void;
+    postCalculateAll: (payload: Record<string, unknown>) => void;
+}
+
+// --- Field state -------------------------------------------------------
+
+interface FieldValues {
+    minTubes: number | undefined;
+    tubeOD: number | undefined;
+    OTLtoShell: number | undefined;
+    tubeClearance: number | undefined;
+    pitchRatio: number | undefined;
+    shellID: number | undefined;
+    actualTubes: number | undefined;
+    layoutOption: number | undefined;
+}
+
+const initialFieldValues: FieldValues = {
+    minTubes: undefined,
+    tubeOD: undefined,
+    OTLtoShell: undefined,
+    tubeClearance: undefined,
+    pitchRatio: undefined,
+    shellID: undefined,
+    actualTubes: undefined,
+    layoutOption: undefined,
+};
+
+// Fields with no derived counterpart.
+const genericFieldNames = [
+    "minTubes",
+    "tubeOD",
+    "OTLtoShell",
+    "shellID",
+    "layoutOption",
+    "actualTubes",
+] as const;
+type GenericFieldName = (typeof genericFieldNames)[number];
+const isGenericFieldName = (name: string): name is GenericFieldName =>
+    (genericFieldNames as readonly string[]).includes(name);
+
+type FieldAction =
+    | { type: "SET_FIELD"; field: GenericFieldName; value: number | undefined }
+    | { type: "SET_TUBE_CLEARANCE"; value: number | undefined }
+    | { type: "SET_PITCH_RATIO"; value: number | undefined };
+
+// True if "next" rounds to the same displayed value (2dp) as a valid "prev".
+const unchangedAtDisplayPrecision = (prev: number | undefined, next: number) =>
+    utils.isNumber(prev) && prev > 0 && utils.trunc(prev, 2) === utils.trunc(next, 2);
+
+function fieldsReducer(state: FieldValues, action: FieldAction): FieldValues {
+    switch (action.type) {
+        case "SET_FIELD":
+            return { ...state, [action.field]: action.value };
+
+        case "SET_TUBE_CLEARANCE": {
+            if (!utils.isNumber(action.value)) {
+                return { ...state, tubeClearance: undefined };
+            }
+            if (unchangedAtDisplayPrecision(state.tubeClearance, action.value)) {
+                return state;
+            }
+            const pitchRatio =
+                utils.isNumber(state.tubeOD) && state.tubeOD > 0
+                    ? 1 + action.value / state.tubeOD
+                    : state.pitchRatio;
+            return { ...state, tubeClearance: action.value, pitchRatio };
+        }
+
+        case "SET_PITCH_RATIO": {
+            if (!utils.isNumber(action.value)) {
+                return { ...state, pitchRatio: undefined };
+            }
+            if (unchangedAtDisplayPrecision(state.pitchRatio, action.value)) {
+                return state;
+            }
+            const tubeClearance = utils.isNumber(state.tubeOD)
+                ? (action.value - 1) * state.tubeOD
+                : state.tubeClearance;
+            return { ...state, pitchRatio: action.value, tubeClearance };
+        }
+
+        default:
+            return state;
+    }
+}
+
+// --- Hook ----------------------------------------------------------------
+
+// Owns every calculation input, validation, input handlers, and triggers
+// worker recalculation on commit
+export function useLayoutForm({
+    lastSingleResult,
+    postCalculateSingle,
+    postCalculateAll,
+}: UseLayoutFormOptions) {
+    const [fields, dispatch] = useReducer(fieldsReducer, initialFieldValues);
+    const [layoutInputsDefined, setLayoutInputsDefined] = useState<boolean>(false);
+    const [layoutOptionSelected, setLayoutOptionSelected] = useState<boolean>(false);
+
+    const setGenericField = useCallback((name: string, value: number | undefined) => {
+        if (isGenericFieldName(name)) {
+            dispatch({ type: "SET_FIELD", field: name, value });
+        } else if (name === "tubeClearance") {
+            dispatch({ type: "SET_TUBE_CLEARANCE", value });
+        } else if (name === "pitchRatio") {
+            dispatch({ type: "SET_PITCH_RATIO", value });
+        } else {
+            console.error(`Field "${name}" not found.`);
+        }
+    }, []);
+
+    // Allow empty values via onAccept to avoid IMask reverting them.
+    const onAcceptEmpty = (value: string, name: string) => {
+        if (value.trim() === "") {
+            setGenericField(name, undefined);
+        }
+    };
+
+    const requestAllLayoutResults = useCallback(
+        (
+            overrides?: Partial<
+                Pick<FieldValues, "OTLtoShell" | "tubeOD" | "pitchRatio" | "minTubes">
+            >,
+        ) => {
+            const effOTLtoShell = overrides?.OTLtoShell ?? fields.OTLtoShell;
+            const effTubeOD = overrides?.tubeOD ?? fields.tubeOD;
+            const effPitchRatio = overrides?.pitchRatio ?? fields.pitchRatio;
+            const effMinTubes = overrides?.minTubes ?? fields.minTubes;
+
+            const valid =
+                utils.isNumber(effOTLtoShell) &&
+                utils.isNumber(effTubeOD) &&
+                utils.isNumber(effPitchRatio) &&
+                utils.isNumber(effMinTubes) &&
+                effOTLtoShell >= 0 &&
+                effTubeOD > 0 &&
+                effPitchRatio >= 1 &&
+                effMinTubes > 0;
+
+            if (!valid) return;
+
+            postCalculateAll({
+                OTLtoShell: effOTLtoShell,
+                tubeOD: effTubeOD,
+                pitchRatio: effPitchRatio,
+                minTubes: effMinTubes,
+            });
+        },
+        [fields.OTLtoShell, fields.tubeOD, fields.pitchRatio, fields.minTubes, postCalculateAll],
+    );
+
+    const onBlur = (e: SyntheticEvent<HTMLInputElement>) => {
+        const val = e.currentTarget.value.replace(",", "");
+        const name = e.currentTarget.name;
+
+        // Emptied field should stay empty
+        if (val.trim() === "") {
+            setGenericField(name, undefined);
+            return;
+        }
+
+        if (!utils.isNumber(val)) {
+            return;
+        }
+        const parsed = utils.stringToNumber(val);
+
+        // tubeClearance/pitchRatio: derive the paired field and, if the
+        // committed value actually changed, ask the worker to refresh every
+        // layout option's preview with the new pitch.
+        if (name === "tubeClearance") {
+            const changed = !unchangedAtDisplayPrecision(fields.tubeClearance, parsed);
+            dispatch({ type: "SET_TUBE_CLEARANCE", value: parsed });
+            if (changed && utils.isNumber(fields.tubeOD) && fields.tubeOD > 0) {
+                requestAllLayoutResults({ pitchRatio: 1 + parsed / fields.tubeOD });
+            }
+            return;
+        }
+
+        if (name === "pitchRatio") {
+            const changed = !unchangedAtDisplayPrecision(fields.pitchRatio, parsed);
+            dispatch({ type: "SET_PITCH_RATIO", value: parsed });
+            if (changed && utils.isNumber(fields.tubeOD)) {
+                requestAllLayoutResults({ pitchRatio: parsed });
+            }
+            return;
+        }
+
+        setGenericField(name, parsed);
+    };
+
+    const inputOnSubmitHandler = (e: React.SubmitEvent<HTMLInputElement>) => {
+        e.preventDefault();
+    };
+
+    // Helper to package and send single-layout calculation requests.
+    const triggerSingleCalculation = useCallback(
+        (overrides?: {
+            overrideLayout?: number;
+            OTLtoShell?: number;
+            tubeOD?: number;
+            pitchRatio?: number;
+            minTubes?: number;
+            shellID?: number;
+        }) => {
+            const effOTLtoShell = overrides?.OTLtoShell ?? fields.OTLtoShell;
+            const effTubeOD = overrides?.tubeOD ?? fields.tubeOD;
+            const effPitchRatio = overrides?.pitchRatio ?? fields.pitchRatio;
+            const effMinTubes = overrides?.minTubes ?? fields.minTubes;
+            const effShellID = overrides?.shellID ?? fields.shellID;
+            const effLayoutOption = overrides?.overrideLayout ?? fields.layoutOption;
+
+            const parsedLayoutOption = effLayoutOption === 0 ? "radial" : effLayoutOption;
+
+            postCalculateSingle({
+                OTLtoShell: effOTLtoShell,
+                tubeOD: effTubeOD,
+                pitchRatio: effPitchRatio,
+                layoutOption: parsedLayoutOption,
+                minTubes: utils.isNumber(effShellID) && effShellID !== 0 ? undefined : effMinTubes,
+                shellID: utils.isNumber(effShellID) && effShellID !== 0 ? effShellID : undefined,
+            });
+        },
+        [
+            fields.OTLtoShell,
+            fields.tubeOD,
+            fields.pitchRatio,
+            fields.minTubes,
+            fields.shellID,
+            fields.layoutOption,
+            postCalculateSingle,
+        ],
+    );
+
+    const formOnSubmitHandler = (e: FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        // Fallback: If form submits, trigger a single calc request
+        if (utils.isNumber(fields.layoutOption) && layoutInputsDefined) {
+            triggerSingleCalculation();
+        }
+    };
+
+    // Handle Enter/Tab: commit field and trigger calc with snapshot.
+    const onKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+        if (e.key !== "Enter" && e.key !== "NumpadEnter" && e.key !== "Tab") {
+            return;
+        }
+
+        if (e.key === "Enter" || e.key === "NumpadEnter") {
+            e.preventDefault();
+        }
+
+        const name = e.currentTarget.name;
+        const raw = e.currentTarget.value.replace(",", "");
+        const committed = utils.isNumber(raw) ? utils.stringToNumber(raw) : undefined;
+
+        const comparableValues: Record<string, number | undefined> = {
+            minTubes: fields.minTubes,
+            tubeOD: fields.tubeOD,
+            OTLtoShell: fields.OTLtoShell,
+            tubeClearance: fields.tubeClearance,
+            pitchRatio: fields.pitchRatio,
+            shellID: fields.shellID,
+        };
+
+        const currentValue = comparableValues[name];
+        const unchanged = (() => {
+            // For "tubeClearance" and "pitchRatio", compare values at
+            // display precision (2 decimals).
+            if (name === "tubeClearance" || name === "pitchRatio") {
+                if (utils.isNumber(committed) && utils.isNumber(currentValue)) {
+                    return utils.trunc(currentValue, 2) === utils.trunc(committed, 2);
+                }
+                return committed === currentValue;
+            }
+            return committed === currentValue;
+        })();
+
+        if (unchanged) {
+            onBlur(e);
+            return;
+        }
+
+        onBlur(e);
+
+        let nextPitchRatio = name === "pitchRatio" ? committed : fields.pitchRatio;
+        let nextTubeClearance = name === "tubeClearance" ? committed : fields.tubeClearance;
+        if (
+            name === "tubeClearance" &&
+            utils.isNumber(committed) &&
+            utils.isNumber(fields.tubeOD) &&
+            fields.tubeOD > 0
+        ) {
+            nextPitchRatio = 1 + committed / fields.tubeOD;
+        } else if (
+            name === "pitchRatio" &&
+            utils.isNumber(committed) &&
+            utils.isNumber(fields.tubeOD)
+        ) {
+            nextTubeClearance = (committed - 1) * fields.tubeOD;
+        }
+
+        // Nothing to recalculate if this field's value is unchanged.
+        const next = {
+            minTubes: name === "minTubes" ? committed : fields.minTubes,
+            tubeOD: name === "tubeOD" ? committed : fields.tubeOD,
+            OTLtoShell: name === "OTLtoShell" ? committed : fields.OTLtoShell,
+            tubeClearance: nextTubeClearance,
+            pitchRatio: nextPitchRatio,
+            shellID: name === "shellID" ? committed : fields.shellID,
+        };
+
+        const inputsValid =
+            utils.isNumber(next.OTLtoShell) &&
+            utils.isNumber(next.tubeOD) &&
+            utils.isNumber(next.tubeClearance) &&
+            utils.isNumber(next.pitchRatio) &&
+            utils.isNumber(next.minTubes) &&
+            next.OTLtoShell >= 0 &&
+            next.tubeOD > 0 &&
+            next.tubeClearance >= 0 &&
+            next.pitchRatio >= 1 &&
+            next.minTubes > 0;
+
+        if (!inputsValid || !utils.isNumber(fields.layoutOption)) {
+            return;
+        }
+
+        triggerSingleCalculation({
+            OTLtoShell: next.OTLtoShell,
+            tubeOD: next.tubeOD,
+            pitchRatio: next.pitchRatio,
+            minTubes: next.minTubes,
+            shellID: next.shellID,
+        });
+    };
+
+    // Regenerate on layout option change and inputs are valid.
+    const onLayoutOptionChange = (e: ChangeEvent<HTMLInputElement>) => {
+        onBlur(e);
+
+        const rawValue = e.currentTarget.value;
+        const parsedValue = utils.isNumber(rawValue) ? utils.stringToNumber(rawValue) : undefined;
+
+        if (!utils.isNumber(parsedValue) || !layoutInputsDefined) {
+            return;
+        }
+
+        triggerSingleCalculation({ overrideLayout: parsedValue });
+    };
+
+    const validateLayoutOption = useCallback(() => {
+        setLayoutOptionSelected(utils.isNumber(fields.layoutOption));
+    }, [fields.layoutOption]);
+
+    const validateLayoutInputs = useCallback(() => {
+        const valid =
+            utils.isNumber(fields.OTLtoShell) &&
+            utils.isNumber(fields.tubeOD) &&
+            utils.isNumber(fields.tubeClearance) &&
+            utils.isNumber(fields.pitchRatio) &&
+            utils.isNumber(fields.minTubes) &&
+            fields.OTLtoShell >= 0 &&
+            fields.tubeOD > 0 &&
+            fields.tubeClearance >= 0 &&
+            fields.pitchRatio >= 1 &&
+            fields.minTubes > 0;
+        setLayoutInputsDefined(valid);
+    }, [
+        fields.OTLtoShell,
+        fields.minTubes,
+        fields.pitchRatio,
+        fields.tubeClearance,
+        fields.tubeOD,
+    ]);
+
+    // Validation
+    useEffect(() => {
+        validateLayoutInputs();
+        validateLayoutOption();
+    }, [validateLayoutInputs, validateLayoutOption]);
+
+    // Actual tubes calculation only when layout option is selected and shell ID is defined
+    useEffect(() => {
+        if (!utils.isNumber(fields.layoutOption)) {
+            return;
+        }
+
+        let selectedLayout: TubeSheet | null = null;
+
+        const parsedLayoutOption = (
+            fields.layoutOption === 0 ? "radial" : fields.layoutOption
+        ) as TubeSheet["layout"];
+
+        if (utils.isNumber(fields.shellID) && fields.shellID > 0) {
+            selectedLayout = layoutInputsDefined
+                ? new TubeSheet(
+                      fields.OTLtoShell!,
+                      fields.tubeOD!,
+                      fields.pitchRatio!,
+                      parsedLayoutOption,
+                      undefined,
+                      fields.shellID,
+                  )
+                : null;
+        }
+
+        if (selectedLayout && selectedLayout.numTubes) {
+            dispatch({ type: "SET_FIELD", field: "actualTubes", value: selectedLayout.numTubes });
+        }
+    }, [
+        fields.OTLtoShell,
+        layoutInputsDefined,
+        fields.layoutOption,
+        fields.pitchRatio,
+        fields.shellID,
+        fields.tubeOD,
+    ]);
+
+    // If a SINGLE_RESULT came back for a custom shell ID, sync actual tubes to it.
+    useEffect(() => {
+        if (lastSingleResult?.shellID && lastSingleResult?.numTubes) {
+            dispatch({
+                type: "SET_FIELD",
+                field: "actualTubes",
+                value: lastSingleResult.numTubes,
+            });
+        }
+    }, [lastSingleResult]);
+
+    return {
+        // Field values
+        minTubes: fields.minTubes,
+        tubeOD: fields.tubeOD,
+        OTLtoShell: fields.OTLtoShell,
+        tubeClearance: fields.tubeClearance,
+        pitchRatio: fields.pitchRatio,
+        shellID: fields.shellID,
+        actualTubes: fields.actualTubes,
+        layoutOption: fields.layoutOption,
+        // Validation
+        layoutInputsDefined,
+        layoutOptionSelected,
+        // Handlers
+        onAcceptEmpty,
+        onBlur,
+        onKeyDown,
+        onLayoutOptionChange,
+        formOnSubmitHandler,
+        inputOnSubmitHandler,
+        triggerSingleCalculation,
+    };
+}

--- a/src/hooks/useSvgExportActions.ts
+++ b/src/hooks/useSvgExportActions.ts
@@ -1,0 +1,61 @@
+import { useCallback, useState } from "react";
+import { downloadBlob, sizedSvgString, svgToPngBlob } from "../utils/svgExport";
+
+export type CopyState = "idle" | "copied" | "error" | "unsupported";
+
+// Encapsulates the "Copy Image" / "Save Image" actions for a rendered
+// SVGSVGElement: clipboard writes (with PNG fallback) and file download.
+export function useSvgExportActions(drawingSVG: SVGSVGElement) {
+    const [copyState, setCopyState] = useState<CopyState>("idle");
+
+    const downloadSVG = useCallback(() => {
+        const blob = new Blob([drawingSVG.outerHTML], { type: "image/svg+xml" });
+        downloadBlob(blob, "tubesheet.svg");
+    }, [drawingSVG]);
+
+    const copySVG = useCallback(() => {
+        if (
+            typeof navigator === "undefined" ||
+            !navigator.clipboard ||
+            typeof ClipboardItem === "undefined"
+        ) {
+            setCopyState("unsupported");
+            return;
+        }
+
+        // Clipboard writes must occur during user activation. Pass pending
+        // Promises to "ClipboardItem" so browsers accept async image data.
+        const { svgString } = sizedSvgString(drawingSVG);
+        const svgBlob = new Blob([svgString], { type: "image/svg+xml;charset=utf-8" });
+        const pngPromise = svgToPngBlob(drawingSVG);
+
+        const onSuccess = () => {
+            setCopyState("copied");
+            setTimeout(() => setCopyState("idle"), 2000);
+        };
+        const onFailure = (err: unknown) => {
+            console.error("Copy to clipboard failed:", err);
+            setCopyState("error");
+            setTimeout(() => setCopyState("idle"), 2500);
+        };
+
+        // SVG with PNG fallback.
+        let writePromise: Promise<void>;
+        try {
+            writePromise = navigator.clipboard.write([
+                new ClipboardItem({ "image/svg+xml": svgBlob, "image/png": pngPromise }),
+            ]);
+        } catch {
+            writePromise = Promise.reject();
+        }
+
+        writePromise.then(onSuccess).catch(() =>
+            navigator.clipboard
+                .write([new ClipboardItem({ "image/png": pngPromise })])
+                .then(onSuccess)
+                .catch(onFailure),
+        );
+    }, [drawingSVG]);
+
+    return { copyState, downloadSVG, copySVG };
+}

--- a/src/hooks/useTubeSheetWorker.ts
+++ b/src/hooks/useTubeSheetWorker.ts
@@ -1,0 +1,199 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { generateTubeSheetSVG, ITubeSheetData } from "../plugins/tubesheet-layout-generator";
+
+export type LayoutResults = {
+    30: (ITubeSheetData & { preferred: boolean }) | null;
+    45: (ITubeSheetData & { preferred: boolean }) | null;
+    60: (ITubeSheetData & { preferred: boolean }) | null;
+    90: (ITubeSheetData & { preferred: boolean }) | null;
+    radial: (ITubeSheetData & { preferred: boolean }) | null;
+};
+
+export type SingleResultPayload = (ITubeSheetData & { shellID?: number; numTubes?: number }) | null;
+
+const emptyLayoutResults: LayoutResults = {
+    "30": null,
+    "45": null,
+    "60": null,
+    "90": null,
+    radial: null,
+};
+
+// Loading badge is debounced so brief calculations don't cause a flash
+// and is held visible for a minimum duration once shown.
+const SHOW_DELAY_MS = 150;
+const MIN_VISIBLE_MS = 300;
+
+// Owns the tubesheet.worker.ts Web Worker.
+// Request/response handling, error/loading state, and announcements.
+// Supports concurrent CALCULATE_ALL/CALCULATE_SINGLE requests.
+// "isCalculating" only clears once all finish.
+export function useTubeSheetWorker(placeholderSVG: SVGSVGElement) {
+    const [layoutResults, setLayoutResults] = useState<LayoutResults>(emptyLayoutResults);
+    const [drawingSVG, setDrawingSVG] = useState<SVGSVGElement>(placeholderSVG);
+    const [lastSingleResult, setLastSingleResult] = useState<SingleResultPayload>(null);
+    const [isCalculating, setIsCalculating] = useState(false);
+    const [showLoadingBadge, setShowLoadingBadge] = useState(false);
+    const [calcError, setCalcError] = useState<string | null>(null);
+    const [announcement, setAnnouncement] = useState("");
+
+    const workerRef = useRef<Worker | null>(null);
+    const loadingShownAtRef = useRef<number | null>(null);
+    const hasRenderedOnceRef = useRef(false);
+
+    // Track outstanding calculations so "isCalculating" clears only when all finish.
+    const pendingCompletionsRef = useRef(0);
+    // Worker responses increment below refs synchronously. Effects drain them
+    // once the corresponding state update has actually committed.
+    const pendingAllResponsesRef = useRef(0);
+    const pendingSingleResponsesRef = useRef(0);
+
+    const beginCalculation = useCallback(() => {
+        pendingCompletionsRef.current += 1;
+        setCalcError(null);
+        setIsCalculating(true);
+    }, []);
+
+    const completeCalculation = useCallback(() => {
+        pendingCompletionsRef.current = Math.max(0, pendingCompletionsRef.current - 1);
+        if (pendingCompletionsRef.current === 0) {
+            setIsCalculating(false);
+        }
+    }, []);
+
+    // Drain counter and call completeCalculation per recorded response.
+    const drainCompletions = useCallback(
+        (counterRef: { current: number }) => {
+            const count = counterRef.current;
+            counterRef.current = 0;
+            for (let i = 0; i < count; i++) {
+                completeCalculation();
+            }
+        },
+        [completeCalculation],
+    );
+
+    // Create the worker once and wire up its message handler.
+    useEffect(() => {
+        const w = new Worker(new URL("../workers/tubesheet.worker.ts", import.meta.url));
+
+        w.onmessage = (event) => {
+            const { type, payload } = event.data;
+
+            if (type === "ALL_RESULTS") {
+                // Count ALL_RESULTS now; an effect will drain and clear "isCalculating".
+                pendingAllResponsesRef.current += 1;
+                setLayoutResults(payload);
+            }
+
+            if (type === "SINGLE_RESULT") {
+                // Count SINGLE_RESULT and set SVG; TubeSheetSVG's "onRendered" clears "isCalculating".
+                pendingSingleResponsesRef.current += 1;
+                setCalcError(null);
+                setDrawingSVG(generateTubeSheetSVG(payload));
+                setLastSingleResult(payload);
+            }
+
+            if (type === "ERROR") {
+                console.error("Worker Error:", payload);
+                setCalcError(typeof payload === "string" ? payload : "Calculation failed.");
+                setAnnouncement(`Calculation failed: ${payload}`);
+                // On ERROR: reset counters, show error, and stop loading.
+                pendingCompletionsRef.current = 0;
+                pendingAllResponsesRef.current = 0;
+                pendingSingleResponsesRef.current = 0;
+                setIsCalculating(false);
+                loadingShownAtRef.current = null;
+                setShowLoadingBadge(false);
+            }
+        };
+
+        workerRef.current = w;
+
+        return () => {
+            w.terminate();
+            workerRef.current = null;
+        };
+    }, []);
+
+    // Debounce showing the loading badge.
+    useEffect(() => {
+        if (isCalculating) {
+            setAnnouncement("Calculating layout…");
+
+            const showTimer = window.setTimeout(() => {
+                loadingShownAtRef.current = Date.now();
+                setShowLoadingBadge(true);
+            }, SHOW_DELAY_MS);
+
+            return () => clearTimeout(showTimer);
+        }
+
+        // Calculation finished. If the badge never actually became visible
+        // the cleanup above already cancelled the timer.
+        if (loadingShownAtRef.current === null) {
+            return;
+        }
+
+        const elapsed = Date.now() - loadingShownAtRef.current;
+        const remaining = Math.max(0, MIN_VISIBLE_MS - elapsed);
+
+        const hideTimer = window.setTimeout(() => {
+            setShowLoadingBadge(false);
+            loadingShownAtRef.current = null;
+        }, remaining);
+
+        return () => clearTimeout(hideTimer);
+    }, [isCalculating]);
+
+    // After layoutResults commit: drain pending ALL_RESULTS count.
+    useEffect(() => {
+        drainCompletions(pendingAllResponsesRef);
+    }, [layoutResults, drainCompletions]);
+
+    // Stable callback for TubeSheetSVG render.
+    const onDrawingRendered = useCallback(() => {
+        // Drain pending SINGLE_RESULT count.
+        drainCompletions(pendingSingleResponsesRef);
+
+        // Skip initial placeholder announcement
+        if (!hasRenderedOnceRef.current) {
+            hasRenderedOnceRef.current = true;
+            return;
+        }
+
+        setAnnouncement("Layout updated.");
+    }, [drainCompletions]);
+
+    const postCalculateSingle = useCallback(
+        (payload: Record<string, unknown>) => {
+            if (!workerRef.current) return;
+            beginCalculation();
+            workerRef.current.postMessage({ type: "CALCULATE_SINGLE", payload });
+        },
+        [beginCalculation],
+    );
+
+    const postCalculateAll = useCallback(
+        (payload: Record<string, unknown>) => {
+            if (!workerRef.current) return;
+            beginCalculation();
+            workerRef.current.postMessage({ type: "CALCULATE_ALL", payload });
+        },
+        [beginCalculation],
+    );
+
+    return {
+        layoutResults,
+        drawingSVG,
+        lastSingleResult,
+        isCalculating,
+        showLoadingBadge,
+        calcError,
+        announcement,
+        setAnnouncement,
+        onDrawingRendered,
+        postCalculateSingle,
+        postCalculateAll,
+    };
+}

--- a/src/utils/svgExport.ts
+++ b/src/utils/svgExport.ts
@@ -1,0 +1,65 @@
+export const downloadBlob = (blob: Blob | MediaSource, filename: string) => {
+    const objectUrl = URL.createObjectURL(blob);
+
+    const link = document.createElement("a");
+    link.href = objectUrl;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+
+    setTimeout(() => URL.revokeObjectURL(objectUrl), 5000);
+};
+
+// Clone svg with explicit pixel dimensions derived from viewBox
+// for SVG and PNG rasterisation.
+export const sizedSvgString = (svg: SVGSVGElement, scale = 2) => {
+    const viewBox = svg.getAttribute("viewBox");
+    const parts = viewBox ? viewBox.split(" ").map(Number) : [0, 0, 300, 150];
+    const vbWidth = parts[2] || 300;
+    const vbHeight = parts[3] || 300;
+    const width = Math.max(1, Math.round(vbWidth * scale));
+    const height = Math.max(1, Math.round(vbHeight * scale));
+
+    const clone = svg.cloneNode(true) as SVGSVGElement;
+    clone.setAttribute("width", `${width}`);
+    clone.setAttribute("height", `${height}`);
+    clone.setAttribute("xmlns", "http://www.w3.org/2000/svg");
+
+    return { svgString: new XMLSerializer().serializeToString(clone), width, height };
+};
+
+// Rasterise SVG to a PNG blob.
+export const svgToPngBlob = (svg: SVGSVGElement, scale = 2): Promise<Blob> => {
+    return new Promise((resolve, reject) => {
+        const { svgString, width, height } = sizedSvgString(svg, scale);
+        const svgBlob = new Blob([svgString], { type: "image/svg+xml;charset=utf-8" });
+        const url = URL.createObjectURL(svgBlob);
+
+        const image = new Image();
+        image.onload = () => {
+            const canvas = document.createElement("canvas");
+            canvas.width = width;
+            canvas.height = height;
+            const ctx = canvas.getContext("2d");
+            URL.revokeObjectURL(url);
+            if (!ctx) {
+                reject(new Error("Canvas 2D context unavailable"));
+                return;
+            }
+            ctx.drawImage(image, 0, 0, width, height);
+            canvas.toBlob((blob) => {
+                if (blob) {
+                    resolve(blob);
+                } else {
+                    reject(new Error("Failed to encode PNG"));
+                }
+            }, "image/png");
+        };
+        image.onerror = () => {
+            URL.revokeObjectURL(url);
+            reject(new Error("Failed to load SVG for rasterisation"));
+        };
+        image.src = url;
+    });
+};


### PR DESCRIPTION
Refactored and modularised the app by moving core logic, effects and independent state management out of "App.tsx" and into hooks.

- Extracted worker and calculation lifecycle management into "./hooks/useTubeSheetWorker.ts"
- Extracted layout form state, validation, and input handling into "./hooks/useLayoutForm.ts"
- Extracted SVG export and clipboard/download actions into "./hooks/useSvgExportActions.ts"
- Extracted custom context menu state/lifecycle into "./hooks/useContextMenu.ts"