### PR TITLE
Optimisations

### DIFF
--- a/src/components/TubeSheetSVG.tsx
+++ b/src/components/TubeSheetSVG.tsx
@@ -7,33 +7,19 @@ type SVGProps = {
 };
 
 export function TubeSheetSVG({ src, className, onRendered }: SVGProps) {
-    const svg = useRef<SVGSVGElement | null>(null); // defining useRef inside component
+    const containerRef = useRef<HTMLDivElement | null>(null);
+
     useEffect(() => {
-        if (svg.current) {
-            // Clear SVG component
-            svg.current.innerHTML = "";
-
-            // Get the children from SVG source and append them to the SVG component
-            Array.from(src.childNodes).forEach((child) => {
-                if (child instanceof SVGElement) {
-                    if (svg.current) {
-                        svg.current.appendChild(child.cloneNode(true));
-                    }
-                }
-            });
-
-            // Copy required attributes
-            svg.current.setAttribute("viewBox", `${src.getAttribute("viewBox")}`);
-            svg.current.setAttribute("title", `${src.getAttribute("title")}`);
-            svg.current.setAttribute("desc", `${src.getAttribute("desc")}`);
-            svg.current.setAttribute("role", `${src.getAttribute("role")}`);
+        const container = containerRef.current;
+        if (container) {
+            if (className) {
+                src.setAttribute("class", className);
+            }
+            container.replaceChildren(src);
         }
 
         onRendered?.();
-    }, [src, onRendered]);
-    return (
-        <>
-            <svg ref={svg} className={className} />
-        </>
-    );
+    }, [src, className, onRendered]);
+
+    return <div ref={containerRef} style={{ display: "contents" }} />;
 }

--- a/src/hooks/useLayoutForm.ts
+++ b/src/hooks/useLayoutForm.ts
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useReducer, useState } from "react";
 import type React from "react";
 import type { ChangeEvent, FormEvent, KeyboardEvent, SyntheticEvent } from "react";
-import { TubeSheet } from "../plugins/tubesheet-layout-generator";
 import { utils } from "../utils/";
 import type { SingleResultPayload } from "./useTubeSheetWorker";
 
@@ -424,41 +423,34 @@ export function useLayoutForm({
         validateLayoutOption();
     }, [validateLayoutInputs, validateLayoutOption]);
 
-    // Actual tubes calculation only when layout option is selected and shell ID is defined
+    // Keep "actual tubes" in sync with a custom shell ID whenever a relevant
+    // input changes (e.g. tubeOD/pitch edited via blur only, without Enter).
+    //
+    // This used to construct a `TubeSheet` directly here, which re-ran the
+    // full min-ID bisection and tube-field generation synchronously on the
+    // main thread just to read off `numTubes` - duplicating work the worker
+    // already does and blocking the UI thread for large tube counts. Instead,
+    // ask the worker to recalculate; its response is picked up by the
+    // "lastSingleResult" effect below, which sets/clears actualTubes.
     useEffect(() => {
-        if (!utils.isNumber(fields.layoutOption)) {
+        if (
+            !utils.isNumber(fields.layoutOption) ||
+            !utils.isNumber(fields.shellID) ||
+            fields.shellID <= 0 ||
+            !layoutInputsDefined
+        ) {
             return;
         }
 
-        let selectedLayout: TubeSheet | null = null;
-
-        const parsedLayoutOption = (
-            fields.layoutOption === 0 ? "radial" : fields.layoutOption
-        ) as TubeSheet["layout"];
-
-        if (utils.isNumber(fields.shellID) && fields.shellID > 0) {
-            selectedLayout = layoutInputsDefined
-                ? new TubeSheet(
-                      fields.OTLtoShell!,
-                      fields.tubeOD!,
-                      fields.pitchRatio!,
-                      parsedLayoutOption,
-                      undefined,
-                      fields.shellID,
-                  )
-                : null;
-        }
-
-        if (selectedLayout && selectedLayout.numTubes) {
-            dispatch({ type: "SET_FIELD", field: "actualTubes", value: selectedLayout.numTubes });
-        }
+        triggerSingleCalculation({ shellID: fields.shellID });
     }, [
         fields.OTLtoShell,
-        layoutInputsDefined,
-        fields.layoutOption,
-        fields.pitchRatio,
-        fields.shellID,
         fields.tubeOD,
+        fields.pitchRatio,
+        fields.layoutOption,
+        fields.shellID,
+        layoutInputsDefined,
+        triggerSingleCalculation,
     ]);
 
     // If a SINGLE_RESULT came back for a custom shell ID, sync actual tubes to it.

--- a/src/plugins/tubesheet-layout-generator.ts
+++ b/src/plugins/tubesheet-layout-generator.ts
@@ -253,7 +253,7 @@ const round = (num: number, decimalPlaces = 0) => {
     return Math.round(n) / p;
 };
 
-const memoHash = (...args: any[]) => JSON.stringify(Array.from(args));
+const memoKey = (...args: Array<number | string | boolean | undefined>): string => args.join("|");
 
 const generateTubeField = memoize(
     (
@@ -419,7 +419,7 @@ const generateTubeField = memoize(
             return null;
         }
     },
-    memoHash,
+    memoKey,
 );
 
 const radialFunc = (
@@ -951,7 +951,7 @@ const findMinID = memoize(
             }
         }
     },
-    memoHash,
+    memoKey,
 );
 
 const generateSVGCircles = <T extends { x: number; y: number }>(

--- a/src/plugins/tubesheet-layout-generator.ts
+++ b/src/plugins/tubesheet-layout-generator.ts
@@ -1,4 +1,5 @@
 import memoize from "lodash.memoize";
+import { LRUCache } from "../utils/LRUCache";
 
 export interface Tube {
     x: number;
@@ -254,6 +255,7 @@ const round = (num: number, decimalPlaces = 0) => {
 };
 
 const memoKey = (...args: Array<number | string | boolean | undefined>): string => args.join("|");
+const MEMO_CACHE_SIZE = 1000;
 
 const generateTubeField = memoize(
     (
@@ -421,6 +423,9 @@ const generateTubeField = memoize(
     },
     memoKey,
 );
+generateTubeField.cache = new LRUCache(
+    MEMO_CACHE_SIZE,
+) as unknown as typeof generateTubeField.cache;
 
 const radialFunc = (
     shellID: number,
@@ -953,6 +958,7 @@ const findMinID = memoize(
     },
     memoKey,
 );
+findMinID.cache = new LRUCache(MEMO_CACHE_SIZE) as unknown as typeof findMinID.cache;
 
 const generateSVGCircles = <T extends { x: number; y: number }>(
     circles: T[],

--- a/src/utils/LRUCache.ts
+++ b/src/utils/LRUCache.ts
@@ -1,0 +1,64 @@
+// Fixed-capacity LRU cache implementing the "Map" methods used by "lodash.memoize",
+// requiring "get", "set", "has", "delete".
+//
+// Example:
+//
+//   const fn = memoize(expensiveFn, hashArgs);
+//   fn.cache = new LRUCache(500);
+//
+// This bounds the cache size instead of using lodash.memoize's default unbounded Map.
+export class LRUCache<K, V> {
+    private readonly maxSize: number;
+    private readonly map = new Map<K, V>();
+
+    constructor(maxSize: number) {
+        if (!Number.isFinite(maxSize) || maxSize <= 0) {
+            throw new Error("LRUCache maxSize must be a positive number");
+        }
+        this.maxSize = maxSize;
+    }
+
+    get size(): number {
+        return this.map.size;
+    }
+
+    has(key: K): boolean {
+        return this.map.has(key);
+    }
+
+    get(key: K): V | undefined {
+        if (!this.map.has(key)) {
+            return undefined;
+        }
+        // Re-insert so this key becomes the most-recently-used entry (Map
+        // iteration/eviction order below is insertion order).
+        const value = this.map.get(key) as V;
+        this.map.delete(key);
+        this.map.set(key, value);
+        return value;
+    }
+
+    set(key: K, value: V): this {
+        if (this.map.has(key)) {
+            // Refresh recency for an existing key.
+            this.map.delete(key);
+        } else if (this.map.size >= this.maxSize) {
+            // Evict the least-recently-used entry: the first key in
+            // insertion order.
+            const oldestKey = this.map.keys().next().value;
+            if (oldestKey !== undefined) {
+                this.map.delete(oldestKey);
+            }
+        }
+        this.map.set(key, value);
+        return this;
+    }
+
+    delete(key: K): boolean {
+        return this.map.delete(key);
+    }
+
+    clear(): void {
+        this.map.clear();
+    }
+}


### PR DESCRIPTION
- Optimised the actual-tubes calculation path in the worker thread.
- Reduced overhead in SVG mounting and rendering.
- Switched memoisation to use concatenated memo keys in lieu of memo hashes (JSON.stringify) for lower overhead.
- Added an LRU cache to prevent unbounded cache growth during long sessions.