### PR TITLE
Paired live-preview fields: pinning, cancel, and preview-config refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ yarn-error.log*
 # dev
 .stylelintrc.json
 .vscode
+*.zip

--- a/src/components/LayoutOptionsList.test.tsx
+++ b/src/components/LayoutOptionsList.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { LayoutOptionsList } from "./LayoutOptionsList";
+import { layoutOptionRows } from "../constants/layoutOptionRows";
+import type { LayoutResults } from "../hooks/useTubeSheetWorker";
+
+// Radial can produce a NaN minID (no tubes fit at the target shell/tube count,
+// so Math.sin(Math.PI / 0) is NaN). This must render as a dash, not the literal
+// text "NaN".
+const layoutResultsWithNaNRadialMinID: LayoutResults = {
+    30: null,
+    45: null,
+    60: null,
+    90: null,
+    radial: {
+        tubeField: [],
+        OTL: null,
+        shellID: 40,
+        minID: NaN,
+        tubeOD: 19.05,
+        pitchRatio: 1.25,
+        layout: "radial",
+        numTubes: 0,
+        preferred: false,
+    },
+};
+
+describe("LayoutOptionsList — NaN minID display", () => {
+    it("renders a dash instead of 'NaN' for the radial row's minID", () => {
+        render(
+            <LayoutOptionsList
+                rows={layoutOptionRows}
+                layoutResults={layoutResultsWithNaNRadialMinID}
+                showLoadingBadge={false}
+                onLayoutOptionChange={() => {}}
+            />,
+        );
+
+        const radialRow = screen.getByLabelText("Radial", { exact: false }).closest("label")!;
+        expect(radialRow).toHaveTextContent("—");
+        expect(radialRow).not.toHaveTextContent("NaN");
+    });
+});

--- a/src/components/LayoutOptionsList.tsx
+++ b/src/components/LayoutOptionsList.tsx
@@ -70,7 +70,7 @@ export function LayoutOptionsList({
                         // Hide stale values while calculating
                         const result = showLoadingBadge ? undefined : layoutResults[key];
                         const minIDValue =
-                            result && result.minID !== null ? (result.minID as number) : undefined;
+                            result && utils.isNumber(result.minID) ? result.minID : undefined;
 
                         return (
                             <label

--- a/src/components/LayoutOptionsList.tsx
+++ b/src/components/LayoutOptionsList.tsx
@@ -70,9 +70,7 @@ export function LayoutOptionsList({
                         // Hide stale values while calculating
                         const result = showLoadingBadge ? undefined : layoutResults[key];
                         const minIDValue =
-                            result && result.minID !== null
-                                ? (result.minID as number)
-                                : undefined;
+                            result && result.minID !== null ? (result.minID as number) : undefined;
 
                         return (
                             <label
@@ -89,7 +87,7 @@ export function LayoutOptionsList({
                                     disabled={showLoadingBadge}
                                     required={required}
                                 />
-                                <span className="row-angle">
+                                <span className="row-angle noselect">
                                     {label}
                                     {result?.preferred && (
                                         <span
@@ -111,7 +109,7 @@ export function LayoutOptionsList({
                                         }}
                                     />
                                 </span>
-                                <span className="row-stats">
+                                <span className="row-stats noselect">
                                     <span className="row-minid">
                                         {minIDValue !== undefined ? (
                                             utils.numFormat3SigFigs(minIDValue)

--- a/src/components/NumericField.test.tsx
+++ b/src/components/NumericField.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import { NumericField } from "./NumericField";
+import { useLayoutForm } from "../hooks/useLayoutForm";
+import { numericFieldConfigs } from "../constants/numericFieldConfigs";
+
+// tubeOD is a plain, non-paired field -- no live-preview/pin machinery, just
+// the generic NumericField + useLayoutForm wiring used throughout App.tsx.
+const tubeODConfig = numericFieldConfigs.find((cfg) => cfg.id === "tubeOD")!;
+
+function Harness() {
+    const form = useLayoutForm({
+        lastSingleResult: null,
+        postCalculateSingle: () => {},
+        postCalculateAll: () => {},
+    });
+
+    return (
+        <>
+            <NumericField
+                {...tubeODConfig}
+                value={form.tubeOD}
+                onBlur={form.onBlur}
+                onKeyDown={form.onKeyDown}
+                onAccept={(value) => form.onAcceptEmpty(value, "tubeOD")}
+                onSubmit={form.inputOnSubmitHandler}
+            />
+            <button type="button">elsewhere</button>
+        </>
+    );
+}
+
+describe("NumericField Escape-to-cancel", () => {
+    it("discards an in-progress edit on a fresh field instead of committing it", async () => {
+        const user = userEvent.setup();
+        render(<Harness />);
+
+        const input = screen.getByLabelText(/^Tube OD/) as HTMLInputElement;
+        await user.click(input);
+        await user.type(input, "25");
+        expect(input.value).toBe("25");
+
+        await user.keyboard("{Escape}");
+
+        // Escape remounts the field (typing is uncontrolled), so re-query it.
+        const reverted = screen.getByLabelText(/^Tube OD/) as HTMLInputElement;
+        expect(reverted.value).toBe(""); // back to empty, nothing committed
+        expect(reverted).not.toHaveClass("field-valid");
+        expect(document.activeElement).not.toBe(reverted);
+    });
+
+    it("reverts to the last committed value, not an empty/typed one", async () => {
+        const user = userEvent.setup();
+        render(<Harness />);
+
+        const input = screen.getByLabelText(/^Tube OD/) as HTMLInputElement;
+        await user.click(input);
+        await user.type(input, "25");
+        await user.tab(); // commit tubeOD = 25
+
+        const committed = screen.getByLabelText(/^Tube OD/) as HTMLInputElement;
+        expect(committed.value).toBe("25");
+        expect(committed).toHaveClass("field-valid");
+
+        // Edit it further, then back out.
+        await user.click(committed);
+        await user.type(committed, "9");
+        await user.keyboard("{Escape}");
+
+        const reverted = screen.getByLabelText(/^Tube OD/) as HTMLInputElement;
+        expect(reverted.value).toBe("25"); // the override never committed
+        expect(reverted).toHaveClass("field-valid");
+        expect(document.activeElement).not.toBe(reverted);
+    });
+
+    it("lets a real commit go through normally after a prior Escape", async () => {
+        const user = userEvent.setup();
+        render(<Harness />);
+
+        const input = screen.getByLabelText(/^Tube OD/) as HTMLInputElement;
+        await user.click(input);
+        await user.type(input, "25");
+        await user.keyboard("{Escape}");
+
+        const reverted = screen.getByLabelText(/^Tube OD/) as HTMLInputElement;
+        await user.click(reverted);
+        await user.type(reverted, "30");
+        await user.tab();
+
+        const committed = screen.getByLabelText(/^Tube OD/) as HTMLInputElement;
+        expect(committed.value).toBe("30");
+        expect(committed).toHaveClass("field-valid");
+    });
+});

--- a/src/components/NumericField.tsx
+++ b/src/components/NumericField.tsx
@@ -1,4 +1,4 @@
-import { memo, useState } from "react";
+import { memo, useRef, useState } from "react";
 import type { KeyboardEvent, SyntheticEvent, SubmitEvent, InputHTMLAttributes } from "react";
 import { NumericFormat } from "react-number-format";
 import { utils } from "../utils";
@@ -26,6 +26,9 @@ export interface NumericFieldProps {
     onFocus?: (e: SyntheticEvent<HTMLInputElement, Event>) => void;
     onBlur?: (e: SyntheticEvent<HTMLInputElement, Event>) => void;
     onKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void;
+    // Extra cleanup for a consumer with its own edit-session state (e.g. a
+    // paired live-preview row). Called before the field's own Escape revert.
+    onEscape?: (e: KeyboardEvent<HTMLInputElement>) => void;
     // "isUserEdit" is true for a real keystroke, false when react-number-format
     // re-fires onValueChange from a programmatic value change (e.g. a preview
     // updating), per its sourceInfo.source ("event" vs "prop").
@@ -54,13 +57,23 @@ function NumericFieldImpl({
     onFocus,
     onBlur,
     onKeyDown,
+    onEscape,
     onAccept,
     onSubmit,
 }: NumericFieldProps) {
     // Errors only surface after the field is left, so a fresh form isn't shown
-    // as invalid up front. Parent can override via "touched" (see PairedFieldRow).
+    // as invalid up front. Parent can override via "touched" (see
+    // PairedFieldRow).
     const [internalTouched, setInternalTouched] = useState(false);
     const touched = touchedProp ?? internalTouched;
+
+    // Bumped on Escape to force a remount: typing is uncontrolled (the "value"
+    // prop intentionally doesn't change while a live preview is frozen), so
+    // without a fresh mount the DOM text won't snap back on cancel.
+    const [resetSeq, setResetSeq] = useState(0);
+    // Suppresses the single blur that Escape triggers, since it fires before
+    // the remount above applies and would otherwise commit the stale DOM text.
+    const escapingRef = useRef(false);
 
     // A paired field can satisfy "required" on its own once it has a value.
     const missingRequired = !utils.isNumber(value) && required && !utils.isNumber(pairedValue);
@@ -68,7 +81,8 @@ function NumericFieldImpl({
         utils.isNumber(value) && utils.isNumber(min) && (minExclusive ? value <= min : value < min);
 
     const errorMessage = (() => {
-        // Preview values (dependent/pinned) aren't user-committed, so never flag them.
+        // Preview values (dependent/pinned) aren't user-committed, so never
+        // flag them.
         if (!touched || readOnly || isPreview) return undefined;
         if (missingRequired) {
             return pairedLabel ? `Required (or ${pairedLabel})` : "Required";
@@ -82,17 +96,36 @@ function NumericFieldImpl({
     const hasError = Boolean(errorMessage);
     const errorId = `${id}-error`;
 
-    // Valid/green state, independent of "touched". Previews don't count until overridden.
+    // Valid/green state, independent of "touched". Previews don't count until
+    // overridden.
     const isValid = !readOnly && !calculated && !isPreview && utils.isNumber(value) && !outOfRange;
 
     // Mirrors missingRequired for native HTML validation on submit.
     const domRequired = required && !utils.isNumber(pairedValue);
 
     const handleBlur = (e: SyntheticEvent<HTMLInputElement, Event>) => {
+        if (escapingRef.current) {
+            escapingRef.current = false; // this blur was Escape's, not a real commit
+            return;
+        }
         if (touchedProp === undefined) {
             setInternalTouched(true);
         }
         onBlur?.(e);
+    };
+
+    // Cancel the in-progress edit: any row-level cleanup first, then remount to
+    // discard the typed DOM text, then leave edit mode.
+    const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === "Escape") {
+            e.preventDefault();
+            escapingRef.current = true;
+            onEscape?.(e);
+            setResetSeq((n) => n + 1);
+            e.currentTarget.blur();
+            return;
+        }
+        onKeyDown?.(e);
     };
 
     return (
@@ -103,6 +136,7 @@ function NumericFieldImpl({
             </label>
             <div className="input-group">
                 <NumericFormat
+                    key={resetSeq}
                     className={`value-input${calculated ? " calculated-field" : ""}${
                         hasError ? " field-invalid" : ""
                     }${isValid ? " field-valid" : ""}${isPreview ? " field-preview" : ""}`}
@@ -118,7 +152,7 @@ function NumericFieldImpl({
                     value={utils.isNumber(value) ? value : ""}
                     onFocus={onFocus}
                     onBlur={handleBlur}
-                    onKeyDown={onKeyDown}
+                    onKeyDown={handleKeyDown}
                     onValueChange={(values, sourceInfo) =>
                         onAccept?.(values.value, sourceInfo.source === "event")
                     }
@@ -139,5 +173,6 @@ function NumericFieldImpl({
     );
 }
 
-// Memoized so unrelated re-renders don't reach the input mid-edit and disrupt typing.
+// Memoized so unrelated re-renders don't reach the input mid-edit and disrupt
+// typing.
 export const NumericField = memo(NumericFieldImpl);

--- a/src/components/NumericField.tsx
+++ b/src/components/NumericField.tsx
@@ -20,18 +20,15 @@ export interface NumericFieldProps {
     pairedLabel?: string;
     touched?: boolean;
     hideAsterisk?: boolean;
-    // True when "value" is a live-preview number shown for direct editing, not
-    // yet an actual user-committed value. Suppresses the valid/green state
-    // until the user overrides it for real.
+    // True when "value" is a live preview, not yet user-committed. Suppresses
+    // valid/error styling until the user overrides it for real.
     isPreview?: boolean;
     onFocus?: (e: SyntheticEvent<HTMLInputElement, Event>) => void;
     onBlur?: (e: SyntheticEvent<HTMLInputElement, Event>) => void;
     onKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void;
-    // "isUserEdit" is true for a real keystroke, and false when
-    // react-number-format re-fires onValueChange because "value" was set
-    // programmatically (e.g. a live preview updating) rather than typed by the
-    // user — react-number-format reports this directly via sourceInfo.source
-    // ("event" vs "prop"), instead of us having to infer it.
+    // "isUserEdit" is true for a real keystroke, false when react-number-format
+    // re-fires onValueChange from a programmatic value change (e.g. a preview
+    // updating), per its sourceInfo.source ("event" vs "prop").
     onAccept?: (value: string, isUserEdit: boolean) => void;
     onSubmit?: (e: SubmitEvent<HTMLInputElement>) => void;
 }
@@ -60,22 +57,19 @@ function NumericFieldImpl({
     onAccept,
     onSubmit,
 }: NumericFieldProps) {
-    // Errors only surface once the user has actually left the field, so a
-    // freshly loaded/empty form isn't shown as invalid before they've typed
-    // anything. A parent can take over this decision via the "touched" prop
-    // (see PairedFieldRow). Otherwise it's tracked internally per-field.
+    // Errors only surface after the field is left, so a fresh form isn't shown
+    // as invalid up front. Parent can override via "touched" (see PairedFieldRow).
     const [internalTouched, setInternalTouched] = useState(false);
     const touched = touchedProp ?? internalTouched;
 
-    // A paired field (e.g. tube clearance / pitch ratio) can satisfy this
-    // requirement on its own — don't flag this one as missing once the other
-    // has a value.
+    // A paired field can satisfy "required" on its own once it has a value.
     const missingRequired = !utils.isNumber(value) && required && !utils.isNumber(pairedValue);
     const outOfRange =
         utils.isNumber(value) && utils.isNumber(min) && (minExclusive ? value <= min : value < min);
 
     const errorMessage = (() => {
-        if (!touched || readOnly) return undefined;
+        // Preview values (dependent/pinned) aren't user-committed, so never flag them.
+        if (!touched || readOnly || isPreview) return undefined;
         if (missingRequired) {
             return pairedLabel ? `Required (or ${pairedLabel})` : "Required";
         }
@@ -88,13 +82,10 @@ function NumericFieldImpl({
     const hasError = Boolean(errorMessage);
     const errorId = `${id}-error`;
 
-    // Positive feedback for a field that actually has a value and satisfies its
-    // own constraints, independent of "touched". A displayed preview doesn't
-    // count until the user actually overrides it.
+    // Valid/green state, independent of "touched". Previews don't count until overridden.
     const isValid = !readOnly && !calculated && !isPreview && utils.isNumber(value) && !outOfRange;
 
-    // Mirrors the error logic above for a paired field to satisft native HTML
-    // validation triggered by the submit button
+    // Mirrors missingRequired for native HTML validation on submit.
     const domRequired = required && !utils.isNumber(pairedValue);
 
     const handleBlur = (e: SyntheticEvent<HTMLInputElement, Event>) => {
@@ -148,8 +139,5 @@ function NumericFieldImpl({
     );
 }
 
-// react-number-format still re-runs formatting on every re-render reachable by
-// the mask, so an unrelated re-render mid-edit could still disrupt typing. Memo
-// means a re-render only reaches the input when one of this field's own props
-// has actually changed.
+// Memoized so unrelated re-renders don't reach the input mid-edit and disrupt typing.
 export const NumericField = memo(NumericFieldImpl);

--- a/src/components/PairedFieldRow.test.tsx
+++ b/src/components/PairedFieldRow.test.tsx
@@ -18,8 +18,8 @@ const OTLtoShellConfig = numericFieldConfigs.find((cfg) => cfg.id === "OTLtoShel
 // doesn't itself cause the paired fields to lose memoization across renders.
 const stubRequestSingle = () => 0;
 
-// Worker stub for the minTubes/shellID pair: echoes back a distinct number per
-// direction so it's obvious in assertions which preview was picked up.
+// Worker stub for the minTubes/shellID pair: echoes back a distinct number
+// per direction so it's obvious in assertions which preview was picked up.
 const workerRequestSingle = (
     payload: Record<string, unknown>,
     callback: (payload: SingleResultPayload) => void,
@@ -273,6 +273,30 @@ describe("PairedFieldRow live preview (tube clearance / pitch ratio)", () => {
         expect(clearanceInput.value).toBe("123");
         expect(Number(pitchInput.value)).toBeCloseTo(5.92, 2); // 1 + 123/25
     });
+
+    it("has no Tab-focus race to guard against: the preview is synchronous", async () => {
+        // compute() runs inline in the keystroke handler (no debounce/worker
+        // round trip), so Tab landing on pitchRatio right after committing
+        // tubeClearance can never arrive before its preview does -- typing
+        // over it should always land normally.
+        const user = userEvent.setup();
+        render(<Harness />);
+        await setTubeOD(user, "25");
+
+        const clearanceInput = screen.getByLabelText("Tube clearance") as HTMLInputElement;
+        await user.click(clearanceInput);
+        await user.type(clearanceInput, "5");
+        await user.tab(); // commits tubeClearance; Tab lands focus on pitchRatio next
+
+        expect(document.activeElement?.id).toBe("pitchRatio");
+
+        const pitchInput = screen.getByLabelText("Pitch ratio") as HTMLInputElement;
+        expect(Number(pitchInput.value)).toBeCloseTo(1.2, 2); // already available, no wait needed
+
+        // Typing on top of it lands normally.
+        await user.keyboard("9");
+        expect(pitchInput.value).not.toBe("");
+    });
 });
 
 describe("PairedFieldRow live preview (min tubes / shell ID)", () => {
@@ -368,6 +392,29 @@ describe("PairedFieldRow live preview (min tubes / shell ID)", () => {
         await user.tab();
         expect(Number(revertedShellIDInput.value)).toBe(45);
         expect(revertedShellIDInput).toHaveClass("field-valid");
+    });
+
+    it("pins the dependent field retroactively when Tab-focus arrives before its preview resolves", async () => {
+        // Regression test for the Tab-focus race: committing minTubes via Tab
+        // moves focus straight to shellID, before its debounced preview has
+        // resolved. Pinning must retry once the preview arrives, or the first
+        // keystroke gets wiped when previewTargetId flips away from shellID.
+        const user = userEvent.setup();
+        render(<WorkerHarness />);
+        await commitMinTubes(user);
+
+        expect(document.activeElement?.id).toBe("shellID"); // Tab landed here
+
+        // Let the debounced worker preview resolve while shellID stays focused.
+        await act(async () => {
+            await new Promise((resolve) => setTimeout(resolve, 400));
+        });
+        const shellIDInput = screen.getByLabelText("Shell ID") as HTMLInputElement;
+        expect(Number(shellIDInput.value)).toBe(88);
+
+        // Type directly on top of the now-settled preview.
+        await user.keyboard("4");
+        expect(shellIDInput.value).not.toBe(""); // the keystroke must land, not vanish
     });
 });
 

--- a/src/components/PairedFieldRow.test.tsx
+++ b/src/components/PairedFieldRow.test.tsx
@@ -10,7 +10,9 @@ import { numericFieldConfigs } from "../constants/numericFieldConfigs";
 // Exercises the tubeClearance/pitchRatio pair (synchronous preview) end to end
 // through the real useLayoutForm reducer, since it needs no worker mock.
 const clearancePitchRow = numericFieldConfigs.filter((cfg) => cfg.row === "clearance-pitch");
+const sizeRow = numericFieldConfigs.filter((cfg) => cfg.row === "minTubes-shellID");
 const tubeODConfig = numericFieldConfigs.find((cfg) => cfg.id === "tubeOD")!;
+const OTLtoShellConfig = numericFieldConfigs.find((cfg) => cfg.id === "OTLtoShell")!;
 // Stable reference (as the real useTubeSheetWorker's requestSingle is) so it
 // doesn't itself cause the paired fields to lose memoization across renders.
 const stubRequestSingle = () => 0;
@@ -43,9 +45,29 @@ function Harness() {
                 onAccept={(value) => form.onAcceptEmpty(value, "tubeOD")}
                 onSubmit={form.inputOnSubmitHandler}
             />
+            <NumericField
+                {...OTLtoShellConfig}
+                value={form.OTLtoShell}
+                onBlur={form.onBlur}
+                onKeyDown={form.onKeyDown}
+                onAccept={(value) => form.onAcceptEmpty(value, "OTLtoShell")}
+                onSubmit={form.inputOnSubmitHandler}
+            />
             <button type="button">elsewhere</button>
             <PairedFieldRow
                 row={clearancePitchRow}
+                fieldValues={fieldValues}
+                layoutOption={form.layoutOption}
+                committedResult={null}
+                isCalculating={false}
+                onBlur={form.onBlur}
+                onKeyDown={form.onKeyDown}
+                onAcceptEmpty={form.onAcceptEmpty}
+                inputOnSubmitHandler={form.inputOnSubmitHandler}
+                requestSingle={stubRequestSingle}
+            />
+            <PairedFieldRow
+                row={sizeRow}
                 fieldValues={fieldValues}
                 layoutOption={form.layoutOption}
                 committedResult={null}
@@ -171,5 +193,52 @@ describe("PairedFieldRow live preview (tube clearance / pitch ratio)", () => {
         await user.type(clearanceInput, "3");
         expect(clearanceInput.value).toBe("123");
         expect(Number(pitchInput.value)).toBeCloseTo(5.92, 2); // 1 + 123/25
+    });
+});
+
+describe("PairedFieldRow shell ID minimum", () => {
+    it("falls back to the generic '> 0' minimum when tubeOD/OTLtoShell aren't known yet", async () => {
+        const user = userEvent.setup();
+        render(<Harness />);
+
+        const shellIDInput = screen.getByLabelText("Shell ID") as HTMLInputElement;
+        const elsewhere = screen.getByRole("button", { name: "elsewhere" });
+
+        await user.click(shellIDInput);
+        await user.type(shellIDInput, "0");
+        await user.click(elsewhere);
+
+        expect(screen.getByText("Must be greater than 0")).toBeInTheDocument();
+    });
+
+    it("uses tubeOD + OTLtoShell as the shell ID minimum once both are known", async () => {
+        const user = userEvent.setup();
+        render(<Harness />);
+
+        await setTubeOD(user, "25");
+
+        const otlInput = screen.getByLabelText(/^OTL to shell/) as HTMLInputElement;
+        await user.click(otlInput);
+        await user.type(otlInput, "5");
+        await user.tab();
+
+        const shellIDInput = screen.getByLabelText("Shell ID") as HTMLInputElement;
+        const elsewhere = screen.getByRole("button", { name: "elsewhere" });
+
+        // Below tubeOD (25) + OTLtoShell (5) = 30, so it should be flagged.
+        await user.click(shellIDInput);
+        await user.type(shellIDInput, "20");
+        await user.click(elsewhere);
+
+        expect(screen.getByText("Must be at least 30")).toBeInTheDocument();
+
+        // Exactly at the minimum is allowed (inclusive).
+        await user.click(shellIDInput);
+        await user.clear(shellIDInput);
+        await user.type(shellIDInput, "30");
+        await user.click(elsewhere);
+
+        expect(screen.queryByText("Must be at least 30")).not.toBeInTheDocument();
+        expect(shellIDInput).toHaveClass("field-valid");
     });
 });

--- a/src/components/PairedFieldRow.test.tsx
+++ b/src/components/PairedFieldRow.test.tsx
@@ -1,11 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import { PairedFieldRow } from "./PairedFieldRow";
 import { NumericField } from "./NumericField";
 import { useLayoutForm } from "../hooks/useLayoutForm";
 import { numericFieldConfigs } from "../constants/numericFieldConfigs";
+import type { SingleResultPayload } from "../hooks/useTubeSheetWorker";
 
 // Exercises the tubeClearance/pitchRatio pair (synchronous preview) end to end
 // through the real useLayoutForm reducer, since it needs no worker mock.
@@ -193,6 +194,127 @@ describe("PairedFieldRow live preview (tube clearance / pitch ratio)", () => {
         await user.type(clearanceInput, "3");
         expect(clearanceInput.value).toBe("123");
         expect(Number(pitchInput.value)).toBeCloseTo(5.92, 2); // 1 + 123/25
+    });
+});
+
+describe("PairedFieldRow live preview (min tubes / shell ID)", () => {
+    it("live-previews the paired minTubes value while shellID is still being typed, before commit", async () => {
+        // Worker stub: given a shellID request, "respond" with a distinct
+        // numTubes preview so it's obvious whether the UI picked it up.
+        const workerRequestSingle = (
+            payload: Record<string, unknown>,
+            callback: (payload: SingleResultPayload) => void,
+        ) => {
+            if (payload.shellID !== undefined) {
+                setTimeout(() => callback({ numTubes: 777 } as SingleResultPayload), 10);
+            } else if (payload.minTubes !== undefined) {
+                setTimeout(() => callback({ shellID: 88 } as SingleResultPayload), 10);
+            }
+            return 1;
+        };
+
+        function WorkerHarness() {
+            const form = useLayoutForm({
+                lastSingleResult: null,
+                postCalculateSingle: () => {},
+                postCalculateAll: () => {},
+            });
+
+            const fieldValues = {
+                minTubes: form.minTubes,
+                tubeOD: form.tubeOD,
+                OTLtoShell: form.OTLtoShell,
+                tubeClearance: form.tubeClearance,
+                pitchRatio: form.pitchRatio,
+                shellID: form.shellID,
+                actualTubes: form.actualTubes,
+                layoutOption: form.layoutOption,
+            };
+
+            return (
+                <>
+                    <NumericField
+                        {...tubeODConfig}
+                        value={form.tubeOD}
+                        onBlur={form.onBlur}
+                        onKeyDown={form.onKeyDown}
+                        onAccept={(value) => form.onAcceptEmpty(value, "tubeOD")}
+                        onSubmit={form.inputOnSubmitHandler}
+                    />
+                    <NumericField
+                        {...OTLtoShellConfig}
+                        value={form.OTLtoShell}
+                        onBlur={form.onBlur}
+                        onKeyDown={form.onKeyDown}
+                        onAccept={(value) => form.onAcceptEmpty(value, "OTLtoShell")}
+                        onSubmit={form.inputOnSubmitHandler}
+                    />
+                    <PairedFieldRow
+                        row={clearancePitchRow}
+                        fieldValues={fieldValues}
+                        layoutOption={form.layoutOption}
+                        committedResult={null}
+                        isCalculating={false}
+                        onBlur={form.onBlur}
+                        onKeyDown={form.onKeyDown}
+                        onAcceptEmpty={form.onAcceptEmpty}
+                        inputOnSubmitHandler={form.inputOnSubmitHandler}
+                        requestSingle={stubRequestSingle}
+                    />
+                    <PairedFieldRow
+                        row={sizeRow}
+                        fieldValues={fieldValues}
+                        layoutOption={form.layoutOption}
+                        committedResult={null}
+                        isCalculating={false}
+                        onBlur={form.onBlur}
+                        onKeyDown={form.onKeyDown}
+                        onAcceptEmpty={form.onAcceptEmpty}
+                        inputOnSubmitHandler={form.inputOnSubmitHandler}
+                        requestSingle={workerRequestSingle}
+                    />
+                </>
+            );
+        }
+
+        const user = userEvent.setup();
+        render(<WorkerHarness />);
+        await setTubeOD(user, "25");
+
+        const OTLInput = screen.getByLabelText(/^OTL to shell/) as HTMLInputElement;
+        await user.click(OTLInput);
+        await user.type(OTLInput, "5");
+        await user.tab();
+
+        // Commit tubeClearance so pitchRatio (required for the size-row live
+        // preview to be considered "ready") is actually defined.
+        const clearanceInput = screen.getByLabelText("Tube clearance") as HTMLInputElement;
+        await user.click(clearanceInput);
+        await user.type(clearanceInput, "5");
+        await user.tab();
+
+        const minTubesInput = screen.getByLabelText("Min # of tubes") as HTMLInputElement;
+        const shellIDInput = screen.getByLabelText("Shell ID") as HTMLInputElement;
+
+        // Commit minTubes = 500. shellID becomes the dependent preview side.
+        await user.click(minTubesInput);
+        await user.type(minTubesInput, "500");
+        await user.tab();
+        expect(Number(minTubesInput.value)).toBe(500);
+
+        // Now start typing into shellID (still uncommitted).
+        await user.click(shellIDInput);
+        await user.type(shellIDInput, "40");
+
+        // Wait past the 350ms debounce for the worker's mocked response.
+        await act(async () => {
+            await new Promise((resolve) => setTimeout(resolve, 400));
+        });
+
+        // minTubes should now live-preview the worker's computed value (777),
+        // not keep showing the stale committed 500.
+        expect(Number(minTubesInput.value)).toBe(777);
+        expect(minTubesInput).toHaveClass("field-preview");
     });
 });
 

--- a/src/components/PairedFieldRow.test.tsx
+++ b/src/components/PairedFieldRow.test.tsx
@@ -217,9 +217,9 @@ describe("PairedFieldRow shell ID minimum", () => {
 
         await setTubeOD(user, "25");
 
-        const otlInput = screen.getByLabelText(/^OTL to shell/) as HTMLInputElement;
-        await user.click(otlInput);
-        await user.type(otlInput, "5");
+        const OTLInput = screen.getByLabelText(/^OTL to shell/) as HTMLInputElement;
+        await user.click(OTLInput);
+        await user.type(OTLInput, "5");
         await user.tab();
 
         const shellIDInput = screen.getByLabelText("Shell ID") as HTMLInputElement;

--- a/src/components/PairedFieldRow.test.tsx
+++ b/src/components/PairedFieldRow.test.tsx
@@ -18,6 +18,84 @@ const OTLtoShellConfig = numericFieldConfigs.find((cfg) => cfg.id === "OTLtoShel
 // doesn't itself cause the paired fields to lose memoization across renders.
 const stubRequestSingle = () => 0;
 
+// Worker stub for the minTubes/shellID pair: echoes back a distinct number per
+// direction so it's obvious in assertions which preview was picked up.
+const workerRequestSingle = (
+    payload: Record<string, unknown>,
+    callback: (payload: SingleResultPayload) => void,
+) => {
+    if (payload.shellID !== undefined) {
+        setTimeout(() => callback({ numTubes: 777 } as SingleResultPayload), 10);
+    } else if (payload.minTubes !== undefined) {
+        setTimeout(() => callback({ shellID: 88 } as SingleResultPayload), 10);
+    }
+    return 1;
+};
+
+function WorkerHarness() {
+    const form = useLayoutForm({
+        lastSingleResult: null,
+        postCalculateSingle: () => {},
+        postCalculateAll: () => {},
+    });
+
+    const fieldValues = {
+        minTubes: form.minTubes,
+        tubeOD: form.tubeOD,
+        OTLtoShell: form.OTLtoShell,
+        tubeClearance: form.tubeClearance,
+        pitchRatio: form.pitchRatio,
+        shellID: form.shellID,
+        actualTubes: form.actualTubes,
+        layoutOption: form.layoutOption,
+    };
+
+    return (
+        <>
+            <NumericField
+                {...tubeODConfig}
+                value={form.tubeOD}
+                onBlur={form.onBlur}
+                onKeyDown={form.onKeyDown}
+                onAccept={(value) => form.onAcceptEmpty(value, "tubeOD")}
+                onSubmit={form.inputOnSubmitHandler}
+            />
+            <NumericField
+                {...OTLtoShellConfig}
+                value={form.OTLtoShell}
+                onBlur={form.onBlur}
+                onKeyDown={form.onKeyDown}
+                onAccept={(value) => form.onAcceptEmpty(value, "OTLtoShell")}
+                onSubmit={form.inputOnSubmitHandler}
+            />
+            <PairedFieldRow
+                row={clearancePitchRow}
+                fieldValues={fieldValues}
+                layoutOption={form.layoutOption}
+                committedResult={null}
+                isCalculating={false}
+                onBlur={form.onBlur}
+                onKeyDown={form.onKeyDown}
+                onAcceptEmpty={form.onAcceptEmpty}
+                inputOnSubmitHandler={form.inputOnSubmitHandler}
+                requestSingle={stubRequestSingle}
+            />
+            <PairedFieldRow
+                row={sizeRow}
+                fieldValues={fieldValues}
+                layoutOption={form.layoutOption}
+                committedResult={null}
+                isCalculating={false}
+                onBlur={form.onBlur}
+                onKeyDown={form.onKeyDown}
+                onAcceptEmpty={form.onAcceptEmpty}
+                inputOnSubmitHandler={form.inputOnSubmitHandler}
+                requestSingle={workerRequestSingle}
+            />
+        </>
+    );
+}
+
 function Harness() {
     const form = useLayoutForm({
         lastSingleResult: null,
@@ -198,87 +276,9 @@ describe("PairedFieldRow live preview (tube clearance / pitch ratio)", () => {
 });
 
 describe("PairedFieldRow live preview (min tubes / shell ID)", () => {
-    it("live-previews the paired minTubes value while shellID is still being typed, before commit", async () => {
-        // Worker stub: given a shellID request, "respond" with a distinct
-        // numTubes preview so it's obvious whether the UI picked it up.
-        const workerRequestSingle = (
-            payload: Record<string, unknown>,
-            callback: (payload: SingleResultPayload) => void,
-        ) => {
-            if (payload.shellID !== undefined) {
-                setTimeout(() => callback({ numTubes: 777 } as SingleResultPayload), 10);
-            } else if (payload.minTubes !== undefined) {
-                setTimeout(() => callback({ shellID: 88 } as SingleResultPayload), 10);
-            }
-            return 1;
-        };
-
-        function WorkerHarness() {
-            const form = useLayoutForm({
-                lastSingleResult: null,
-                postCalculateSingle: () => {},
-                postCalculateAll: () => {},
-            });
-
-            const fieldValues = {
-                minTubes: form.minTubes,
-                tubeOD: form.tubeOD,
-                OTLtoShell: form.OTLtoShell,
-                tubeClearance: form.tubeClearance,
-                pitchRatio: form.pitchRatio,
-                shellID: form.shellID,
-                actualTubes: form.actualTubes,
-                layoutOption: form.layoutOption,
-            };
-
-            return (
-                <>
-                    <NumericField
-                        {...tubeODConfig}
-                        value={form.tubeOD}
-                        onBlur={form.onBlur}
-                        onKeyDown={form.onKeyDown}
-                        onAccept={(value) => form.onAcceptEmpty(value, "tubeOD")}
-                        onSubmit={form.inputOnSubmitHandler}
-                    />
-                    <NumericField
-                        {...OTLtoShellConfig}
-                        value={form.OTLtoShell}
-                        onBlur={form.onBlur}
-                        onKeyDown={form.onKeyDown}
-                        onAccept={(value) => form.onAcceptEmpty(value, "OTLtoShell")}
-                        onSubmit={form.inputOnSubmitHandler}
-                    />
-                    <PairedFieldRow
-                        row={clearancePitchRow}
-                        fieldValues={fieldValues}
-                        layoutOption={form.layoutOption}
-                        committedResult={null}
-                        isCalculating={false}
-                        onBlur={form.onBlur}
-                        onKeyDown={form.onKeyDown}
-                        onAcceptEmpty={form.onAcceptEmpty}
-                        inputOnSubmitHandler={form.inputOnSubmitHandler}
-                        requestSingle={stubRequestSingle}
-                    />
-                    <PairedFieldRow
-                        row={sizeRow}
-                        fieldValues={fieldValues}
-                        layoutOption={form.layoutOption}
-                        committedResult={null}
-                        isCalculating={false}
-                        onBlur={form.onBlur}
-                        onKeyDown={form.onKeyDown}
-                        onAcceptEmpty={form.onAcceptEmpty}
-                        inputOnSubmitHandler={form.inputOnSubmitHandler}
-                        requestSingle={workerRequestSingle}
-                    />
-                </>
-            );
-        }
-
-        const user = userEvent.setup();
-        render(<WorkerHarness />);
+    // Commits tubeOD/OTLtoShell/tubeClearance and minTubes=500 so shellID is
+    // ready to live-preview off the worker stub (shellID -> 88).
+    async function commitMinTubes(user: ReturnType<typeof userEvent.setup>) {
         await setTubeOD(user, "25");
 
         const OTLInput = screen.getByLabelText(/^OTL to shell/) as HTMLInputElement;
@@ -294,13 +294,19 @@ describe("PairedFieldRow live preview (min tubes / shell ID)", () => {
         await user.tab();
 
         const minTubesInput = screen.getByLabelText("Min # of tubes") as HTMLInputElement;
-        const shellIDInput = screen.getByLabelText("Shell ID") as HTMLInputElement;
-
-        // Commit minTubes = 500. shellID becomes the dependent preview side.
         await user.click(minTubesInput);
         await user.type(minTubesInput, "500");
         await user.tab();
         expect(Number(minTubesInput.value)).toBe(500);
+    }
+
+    it("live-previews the paired minTubes value while shellID is still being typed, before commit", async () => {
+        const user = userEvent.setup();
+        render(<WorkerHarness />);
+        await commitMinTubes(user);
+
+        const minTubesInput = screen.getByLabelText("Min # of tubes") as HTMLInputElement;
+        const shellIDInput = screen.getByLabelText("Shell ID") as HTMLInputElement;
 
         // Now start typing into shellID (still uncommitted).
         await user.click(shellIDInput);
@@ -315,6 +321,53 @@ describe("PairedFieldRow live preview (min tubes / shell ID)", () => {
         // not keep showing the stale committed 500.
         expect(Number(minTubesInput.value)).toBe(777);
         expect(minTubesInput).toHaveClass("field-preview");
+    });
+
+    it("Escape cancels an in-progress edit and restores the prior live preview", async () => {
+        const user = userEvent.setup();
+        render(<WorkerHarness />);
+        await commitMinTubes(user);
+
+        const minTubesInput = screen.getByLabelText("Min # of tubes") as HTMLInputElement;
+        const shellIDInput = screen.getByLabelText("Shell ID") as HTMLInputElement;
+
+        // Pre-edit: minTubes is its own committed, non-muted value.
+        expect(minTubesInput).toHaveClass("field-valid");
+        expect(minTubesInput).not.toHaveClass("field-preview");
+
+        // Start typing into shellID, then back out before committing.
+        await user.click(shellIDInput);
+        await user.type(shellIDInput, "40");
+        expect(shellIDInput.value).toBe("40");
+        await user.keyboard("{Escape}");
+
+        // The Escape revert remounts the input (typing is uncontrolled, so a
+        // fresh mount is what forces the DOM text to reset) -- re-query it.
+        const revertedShellIDInput = screen.getByLabelText("Shell ID") as HTMLInputElement;
+
+        // Nothing from the cancelled edit was committed, and focus is released.
+        expect(revertedShellIDInput.value).not.toBe("40");
+        expect(revertedShellIDInput).not.toHaveClass("field-valid");
+        expect(document.activeElement).not.toBe(revertedShellIDInput);
+
+        // minTubes goes back to its own committed, non-muted display -- the
+        // in-progress "shellID is driving" flip is undone.
+        expect(Number(minTubesInput.value)).toBe(500);
+        expect(minTubesInput).not.toHaveClass("field-preview");
+        expect(minTubesInput).toHaveClass("field-valid");
+
+        // The cancelled edit's debounced request doesn't resurrect itself.
+        await act(async () => {
+            await new Promise((resolve) => setTimeout(resolve, 400));
+        });
+        expect(Number(minTubesInput.value)).toBe(500);
+
+        // A real commit still works normally afterwards.
+        await user.click(revertedShellIDInput);
+        await user.type(revertedShellIDInput, "45");
+        await user.tab();
+        expect(Number(revertedShellIDInput.value)).toBe(45);
+        expect(revertedShellIDInput).toHaveClass("field-valid");
     });
 });
 

--- a/src/components/PairedFieldRow.tsx
+++ b/src/components/PairedFieldRow.tsx
@@ -256,7 +256,13 @@ export function PairedFieldRow({
             }
         } else if (hasLivePreview && cfg.id === previewTargetId) {
             // Committed but still the dependent side of the pair – stays muted
-            // to show which field is driving vs. computed.
+            // to show which field is driving vs. computed. Swap in the freshly
+            // computed preview number (once available) instead of leaving the
+            // stale committed value on screen.
+            const preview = previewNumberFor(cfg.id);
+            if (utils.isNumber(preview)) {
+                fieldValue = preview;
+            }
             isPreview = true;
         }
 

--- a/src/components/PairedFieldRow.tsx
+++ b/src/components/PairedFieldRow.tsx
@@ -2,14 +2,10 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { KeyboardEvent, SubmitEvent, SyntheticEvent } from "react";
 import { NumericField } from "./NumericField";
 import type { NumericFieldConfig } from "../constants/numericFieldConfigs";
+import { pairPreviewConfigs, type CommittedSizeResult } from "../constants/pairPreviewConfigs";
 import { useLivePreview } from "../hooks/useLivePreview";
 import type { SingleResultPayload } from "../hooks/useTubeSheetWorker";
 import { utils } from "../utils";
-
-interface CommittedSizeResult {
-    minID: number | null;
-    numTubes: number | null;
-}
 
 interface PairedFieldRowProps {
     row: NumericFieldConfig[];
@@ -55,11 +51,11 @@ export function PairedFieldRow({
     const pinDirtyRef = useRef(false);
 
     const rowFieldIds = useMemo(() => row.map((cfg) => cfg.id), [row]);
-    const isSizeRow = rowFieldIds.includes("minTubes") && rowFieldIds.includes("shellID");
-    const isClearancePitchRow =
-        rowFieldIds.includes("tubeClearance") && rowFieldIds.includes("pitchRatio");
-    // Only these two paired rows currently support a live preview.
-    const hasLivePreview = isSizeRow || isClearancePitchRow;
+    const rowId = row[0]?.row;
+    // Rows opt into a live preview via a pairPreviewConfigs entry.
+    const previewConfig = rowId ? pairPreviewConfigs[rowId] : undefined;
+    const hasLivePreview = !!previewConfig;
+    const isWorkerPreview = previewConfig?.kind === "worker";
 
     const livePreview = useLivePreview(requestSingle);
     const requestPreview = livePreview.request;
@@ -71,9 +67,6 @@ export function PairedFieldRow({
         onAcceptEmpty,
         inputOnSubmitHandler,
         fieldValues,
-        OTLToShell: fieldValues.OTLtoShell,
-        tubeOD: fieldValues.tubeOD,
-        pitchRatio: fieldValues.pitchRatio,
         layoutOption,
         pinnedFieldId: pinnedField?.id,
         previewByField: {} as Record<string, number | undefined>,
@@ -93,38 +86,19 @@ export function PairedFieldRow({
     // Current live-preview number for a field, if any.
     const previewNumberFor = useCallback(
         (fieldId: string): number | undefined => {
-            if (!hasLivePreview || fieldId !== previewTargetId) return undefined;
-            if (isSizeRow) {
-                if (fieldId === "shellID") {
-                    if (utils.isNumber(livePreview.result?.shellID))
-                        return livePreview.result.shellID;
-                    if (
-                        utils.isNumber(fieldValues.minTubes) &&
-                        utils.isNumber(committedResult?.minID)
-                    ) {
-                        return committedResult.minID;
-                    }
-                } else if (fieldId === "minTubes") {
-                    if (utils.isNumber(livePreview.result?.numTubes))
-                        return livePreview.result.numTubes;
-                    if (
-                        utils.isNumber(fieldValues.shellID) &&
-                        utils.isNumber(committedResult?.numTubes)
-                    ) {
-                        return committedResult.numTubes;
-                    }
-                }
-                return undefined;
+            if (!previewConfig || fieldId !== previewTargetId) return undefined;
+            if (previewConfig.kind === "worker") {
+                const fromResult = previewConfig.extractResult(fieldId, livePreview.result);
+                if (utils.isNumber(fromResult)) return fromResult;
+                return previewConfig.fallbackFromCommitted(fieldId, fieldValues, committedResult);
             }
-            return syncPreview; // clearance/pitch
+            return syncPreview; // formula-driven row
         },
         [
-            hasLivePreview,
-            isSizeRow,
+            previewConfig,
             previewTargetId,
             livePreview.result,
-            fieldValues.minTubes,
-            fieldValues.shellID,
+            fieldValues,
             committedResult,
             syncPreview,
         ],
@@ -139,9 +113,6 @@ export function PairedFieldRow({
             onAcceptEmpty,
             inputOnSubmitHandler,
             fieldValues,
-            OTLToShell: fieldValues.OTLtoShell,
-            tubeOD: fieldValues.tubeOD,
-            pitchRatio: fieldValues.pitchRatio,
             layoutOption,
             pinnedFieldId: pinnedField?.id,
             previewByField: {
@@ -224,35 +195,21 @@ export function PairedFieldRow({
             const otherId = row[0].id === fieldId ? row[1].id : row[0].id;
             setPreviewTargetId(otherId);
 
-            if (isSizeRow) {
-                const { OTLToShell, tubeOD, pitchRatio, layoutOption: lo } = latest.current;
-                const geometryReady =
-                    utils.isNumber(OTLToShell) &&
-                    OTLToShell >= 0 &&
-                    utils.isNumber(tubeOD) &&
-                    tubeOD > 0 &&
-                    utils.isNumber(pitchRatio) &&
-                    pitchRatio >= 1;
-                if (!geometryReady) return;
+            if (!previewConfig) return;
+            const ctx = {
+                ...latest.current.fieldValues,
+                layoutOption: latest.current.layoutOption,
+            };
 
+            if (previewConfig.kind === "worker") {
+                if (!previewConfig.isReady(ctx)) return;
                 // useLivePreview already debounces.
-                requestPreview({
-                    OTLtoShell: OTLToShell,
-                    tubeOD,
-                    pitchRatio,
-                    layoutOption: utils.isNumber(lo) ? lo : 30,
-                    minTubes: fieldId === "minTubes" ? parsed : undefined,
-                    shellID: fieldId === "shellID" ? parsed : undefined,
-                });
-            } else if (isClearancePitchRow) {
-                const preview =
-                    fieldId === "tubeClearance"
-                        ? utils.pitchRatioFromClearance(latest.current.tubeOD, parsed)
-                        : utils.clearanceFromPitchRatio(latest.current.tubeOD, parsed);
-                setSyncPreview(preview);
+                requestPreview(previewConfig.buildRequest(fieldId, parsed, ctx));
+            } else {
+                setSyncPreview(previewConfig.compute(fieldId, parsed, ctx));
             }
         },
-        [clearDraft, requestPreview, row, isSizeRow, isClearancePitchRow],
+        [clearDraft, requestPreview, row, previewConfig],
     );
 
     const acceptFieldA = useCallback(
@@ -270,23 +227,14 @@ export function PairedFieldRow({
 
     const rowHint = row.find((cfg) => cfg.rowHint)?.rowHint;
 
-    // Shell ID's physical minimum is tubeOD + OTLtoShell; falls back to the
-    // static "> 0" config until both are known.
-    const shellIDMinReady =
-        utils.isNumber(fieldValues.tubeOD) && utils.isNumber(fieldValues.OTLtoShell);
-    const shellIDMin = shellIDMinReady
-        ? utils.round((fieldValues.tubeOD as number) + (fieldValues.OTLtoShell as number), 2)
-        : undefined;
-
     const fields = row.map((cfg, i) => {
         const isPinned = hasLivePreview && pinnedField?.id === cfg.id;
         let fieldValue = fieldValues[cfg.id];
         let isPreview = false;
         let placeholder = cfg.placeholder;
-        const isShellIDField = cfg.id === "shellID";
-        const fieldMin = isShellIDField && shellIDMinReady ? shellIDMin : cfg.min;
-        // Inclusive: the computed minimum is itself achievable.
-        const fieldMinExclusive = isShellIDField && shellIDMinReady ? false : cfg.minExclusive;
+        const dynamicBound = cfg.dynamicMin?.(fieldValues);
+        const fieldMin = dynamicBound ? dynamicBound.min : cfg.min;
+        const fieldMinExclusive = dynamicBound ? dynamicBound.minExclusive : cfg.minExclusive;
 
         if (hasLivePreview && fieldValue === undefined) {
             if (isPinned) {
@@ -300,7 +248,7 @@ export function PairedFieldRow({
                     isPreview = true;
                 } else if (
                     cfg.id === previewTargetId &&
-                    isSizeRow &&
+                    isWorkerPreview &&
                     livePreview.status === "pending"
                 ) {
                     placeholder = "…";

--- a/src/components/PairedFieldRow.tsx
+++ b/src/components/PairedFieldRow.tsx
@@ -49,6 +49,11 @@ export function PairedFieldRow({
     const [syncPreview, setSyncPreview] = useState<number | undefined>(undefined);
     // True once the pinned field was actually typed into, not just focused.
     const pinDirtyRef = useRef(false);
+    // Row-level preview state snapshotted on focus, restored on Escape.
+    const editSnapshotRef = useRef<{
+        previewTargetId: string | undefined;
+        syncPreview: number | undefined;
+    } | null>(null);
 
     const rowFieldIds = useMemo(() => row.map((cfg) => cfg.id), [row]);
     const rowId = row[0]?.row;
@@ -70,6 +75,8 @@ export function PairedFieldRow({
         layoutOption,
         pinnedFieldId: pinnedField?.id,
         previewByField: {} as Record<string, number | undefined>,
+        previewTargetId,
+        syncPreview,
     });
 
     // Only clears on empty/invalid input, not on blur.
@@ -119,13 +126,20 @@ export function PairedFieldRow({
                 [row[0].id]: previewNumberFor(row[0].id),
                 [row[1].id]: previewNumberFor(row[1].id),
             },
+            previewTargetId,
+            syncPreview,
         };
     });
 
-    // Focusing a previewed field freezes its shown value for the edit session.
+    // Focusing a previewed field freezes its shown value for the edit session,
+    // and snapshots row state so Escape can restore it.
     const handleFieldFocus = useCallback(
         (e: SyntheticEvent<HTMLInputElement>) => {
             if (!hasLivePreview) return;
+            editSnapshotRef.current = {
+                previewTargetId: latest.current.previewTargetId,
+                syncPreview: latest.current.syncPreview,
+            };
             const id = e.currentTarget.id;
             if (utils.isNumber(latest.current.fieldValues[id])) return; // already real
             const shown = latest.current.previewByField[id];
@@ -135,6 +149,18 @@ export function PairedFieldRow({
         },
         [hasLivePreview],
     );
+
+    // Cancel this edit session: undo the pin and restore the previewed side to
+    // what it was before this field was focused.
+    const handleFieldEscape = useCallback(() => {
+        if (!hasLivePreview) return;
+        pinDirtyRef.current = false; // set before NumericField's blur() fires
+        setPinnedField(null);
+        cancelPreview();
+        const snapshot = editSnapshotRef.current;
+        setPreviewTargetId(snapshot?.previewTargetId);
+        setSyncPreview(snapshot?.syncPreview);
+    }, [hasLivePreview, cancelPreview]);
 
     const handleFieldBlur = useCallback(
         (e: SyntheticEvent<HTMLInputElement>) => {
@@ -238,7 +264,8 @@ export function PairedFieldRow({
 
         if (hasLivePreview && fieldValue === undefined) {
             if (isPinned) {
-                // Frozen at focus time; DOM (read on blur) holds the real typed value.
+                // Frozen at focus time; DOM (read on blur) holds the real typed
+                // value.
                 fieldValue = pinnedField!.value;
                 isPreview = true;
             } else {
@@ -282,6 +309,7 @@ export function PairedFieldRow({
                 onFocus={cfg.calculated ? undefined : handleFieldFocus}
                 onBlur={cfg.calculated ? undefined : handleFieldBlur}
                 onKeyDown={cfg.calculated ? undefined : handleFieldKeyDown}
+                onEscape={cfg.calculated ? undefined : handleFieldEscape}
                 onAccept={
                     cfg.calculated
                         ? undefined

--- a/src/components/PairedFieldRow.tsx
+++ b/src/components/PairedFieldRow.tsx
@@ -49,6 +49,10 @@ export function PairedFieldRow({
     const [syncPreview, setSyncPreview] = useState<number | undefined>(undefined);
     // True once the pinned field was actually typed into, not just focused.
     const pinDirtyRef = useRef(false);
+    // Which field in the row is currently focused (if any) -- lets a preview
+    // that resolves after focus (e.g. Tab lands here before a debounced worker
+    // result arrives) still get pinned retroactively.
+    const focusedFieldIdRef = useRef<string | undefined>(undefined);
     // Row-level preview state snapshotted on focus, restored on Escape.
     const editSnapshotRef = useRef<{
         previewTargetId: string | undefined;
@@ -131,19 +135,33 @@ export function PairedFieldRow({
         };
     });
 
+    // A preview can resolve after focus (e.g. Tab lands on the dependent field
+    // before its debounced worker value arrives) -- pin it retroactively so the
+    // first keystroke doesn't fight the value that just showed up.
+    useEffect(() => {
+        const focusedId = focusedFieldIdRef.current;
+        if (!focusedId || pinnedField?.id === focusedId || pinDirtyRef.current) return;
+        if (fieldValues[focusedId] !== undefined) return; // already committed
+        const preview = previewNumberFor(focusedId);
+        if (utils.isNumber(preview)) {
+            setPinnedField({ id: focusedId, value: preview });
+        }
+    }, [fieldValues, pinnedField, previewNumberFor]);
+
     // Focusing a previewed field freezes its shown value for the edit session,
     // and snapshots row state so Escape can restore it.
     const handleFieldFocus = useCallback(
         (e: SyntheticEvent<HTMLInputElement>) => {
             if (!hasLivePreview) return;
+            const id = e.currentTarget.id;
+            focusedFieldIdRef.current = id;
             editSnapshotRef.current = {
                 previewTargetId: latest.current.previewTargetId,
                 syncPreview: latest.current.syncPreview,
             };
-            const id = e.currentTarget.id;
             if (utils.isNumber(latest.current.fieldValues[id])) return; // already real
             const shown = latest.current.previewByField[id];
-            if (!utils.isNumber(shown)) return; // nothing to pin
+            if (!utils.isNumber(shown)) return; // nothing to pin yet; retried above
             pinDirtyRef.current = false;
             setPinnedField({ id, value: shown });
         },
@@ -154,6 +172,7 @@ export function PairedFieldRow({
     // what it was before this field was focused.
     const handleFieldEscape = useCallback(() => {
         if (!hasLivePreview) return;
+        focusedFieldIdRef.current = undefined;
         pinDirtyRef.current = false; // set before NumericField's blur() fires
         setPinnedField(null);
         cancelPreview();
@@ -171,6 +190,7 @@ export function PairedFieldRow({
             }
 
             const id = e.currentTarget.id;
+            if (focusedFieldIdRef.current === id) focusedFieldIdRef.current = undefined;
             if (id === latest.current.pinnedFieldId) {
                 const wasEdited = pinDirtyRef.current;
                 setPinnedField(null);

--- a/src/components/PairedFieldRow.tsx
+++ b/src/components/PairedFieldRow.tsx
@@ -28,8 +28,7 @@ interface PairedFieldRowProps {
     ) => number;
 }
 
-// A pinned preview: the field id currently showing a live-preview number that
-// the user has focused, plus the number it was frozen at when focus began.
+// Field id + value frozen when a live-preview field gains focus.
 interface PinnedField {
     id: string;
     value: number;
@@ -50,20 +49,16 @@ export function PairedFieldRow({
     const [rowTouched, setRowTouched] = useState(false);
     const [previewTargetId, setPreviewTargetId] = useState<string | undefined>(undefined);
     const [pinnedField, setPinnedField] = useState<PinnedField | null>(null);
-    // Synchronously-derived preview (tubeClearance/pitchRatio). The size row
-    // uses the async worker-backed livePreview.result instead.
+    // Sync preview for clearance/pitch; the size row uses livePreview.result.
     const [syncPreview, setSyncPreview] = useState<number | undefined>(undefined);
-    // Whether the pinned field was actually edited (vs. just focused/blurred
-    // without typing). Imperative so it can be read from stable callbacks.
+    // True once the pinned field was actually typed into, not just focused.
     const pinDirtyRef = useRef(false);
 
     const rowFieldIds = useMemo(() => row.map((cfg) => cfg.id), [row]);
     const isSizeRow = rowFieldIds.includes("minTubes") && rowFieldIds.includes("shellID");
     const isClearancePitchRow =
         rowFieldIds.includes("tubeClearance") && rowFieldIds.includes("pitchRatio");
-    // Both currently-paired rows support an editable live preview. A future
-    // paired row without a preview strategy below just falls back to plain
-    // paired-field behavior (no preview, no pinning).
+    // Only these two paired rows currently support a live preview.
     const hasLivePreview = isSizeRow || isClearancePitchRow;
 
     const livePreview = useLivePreview(requestSingle);
@@ -84,18 +79,18 @@ export function PairedFieldRow({
         previewByField: {} as Record<string, number | undefined>,
     });
 
-    // Clear draft only when the user empties the field or invalidates it.
+    // Only clears on empty/invalid input, not on blur.
     const clearDraft = useCallback(() => {
         setPreviewTargetId(undefined);
         setPinnedField(null);
         setSyncPreview(undefined);
         pinDirtyRef.current = false;
-        cancelPreview(); // stop any pending worker request (no-op if unused)
+        cancelPreview();
     }, [cancelPreview]);
 
     useEffect(() => clearDraft, [clearDraft]);
 
-    // The number currently shown as a live preview for a given field, if any.
+    // Current live-preview number for a field, if any.
     const previewNumberFor = useCallback(
         (fieldId: string): number | undefined => {
             if (!hasLivePreview || fieldId !== previewTargetId) return undefined;
@@ -121,7 +116,7 @@ export function PairedFieldRow({
                 }
                 return undefined;
             }
-            return syncPreview; // clearance/pitch: derived synchronously on accept
+            return syncPreview; // clearance/pitch
         },
         [
             hasLivePreview,
@@ -135,11 +130,8 @@ export function PairedFieldRow({
         ],
     );
 
-    // Snapshot each field's current preview after every render. Read from
-    // handleFieldFocus below via the ref (not as a useCallback dependency) so
-    // that callback's identity stays stable across keystrokes – otherwise it
-    // would break memo on the field currently being typed into as well, and an
-    // unrelated re-render mid-edit could disrupt the mask's own state.
+    // Snapshot latest previews/props into a ref so callbacks below stay
+    // referentially stable across keystrokes (avoids breaking field memo).
     useEffect(() => {
         latest.current = {
             onBlur,
@@ -159,16 +151,14 @@ export function PairedFieldRow({
         };
     });
 
-    // Entering a field that's showing a preview freezes that number as the
-    // field's controlled value for the rest of the edit session, so the mask
-    // isn't fought mid-edit by new preview results or previewTargetId flips.
+    // Focusing a previewed field freezes its shown value for the edit session.
     const handleFieldFocus = useCallback(
         (e: SyntheticEvent<HTMLInputElement>) => {
             if (!hasLivePreview) return;
             const id = e.currentTarget.id;
             if (utils.isNumber(latest.current.fieldValues[id])) return; // already real
             const shown = latest.current.previewByField[id];
-            if (!utils.isNumber(shown)) return; // nothing shown yet to pin
+            if (!utils.isNumber(shown)) return; // nothing to pin
             pinDirtyRef.current = false;
             setPinnedField({ id, value: shown });
         },
@@ -188,13 +178,11 @@ export function PairedFieldRow({
                 const wasEdited = pinDirtyRef.current;
                 setPinnedField(null);
                 pinDirtyRef.current = false;
-                // Untouched preview: leaving without typing must not commit the
-                // shown number as if the user had entered it.
+                // Don't commit an untouched preview as if the user typed it.
                 if (!wasEdited) return;
             }
 
-            // Do NOT clear draft or cancel preview on blur – keep showing last
-            // preview.
+            // Keep showing the last preview; don't clear on blur.
             latest.current.onBlur(e);
         },
         [rowFieldIds],
@@ -204,11 +192,11 @@ export function PairedFieldRow({
         const id = e.currentTarget.id;
         const isCommitKey = e.key === "Enter" || e.key === "NumpadEnter" || e.key === "Tab";
         if (id === latest.current.pinnedFieldId && !pinDirtyRef.current && isCommitKey) {
-            // Nothing typed yet – don't commit the untouched preview.
+            // Don't commit an untouched preview.
             if (e.key !== "Tab") e.preventDefault();
             return;
         }
-        // Do NOT clear draft or cancel preview – keep showing last preview.
+        // Keep showing the last preview.
         latest.current.onKeyDown(e);
     }, []);
 
@@ -218,20 +206,18 @@ export function PairedFieldRow({
 
     const handlePairFieldAccept = useCallback(
         (value: string, fieldId: string, isUserEdit: boolean) => {
-            // react-number-format re-fires onValueChange whenever a field's
-            // controlled "value" prop is updated even programmatically (e.g.
-            // the OTHER field's preview just changed and re-rendered this one)
-            // — sourceInfo.source distinguishes that from a real keystroke.
+            // sourceInfo.source distinguishes a real keystroke from a
+            // programmatic value update (e.g. the paired field's preview).
             if (!isUserEdit) return;
             if (fieldId === latest.current.pinnedFieldId) {
-                pinDirtyRef.current = true; // a real edit, not just a shown preview
+                pinDirtyRef.current = true; // real edit, not just a shown preview
             }
 
             latest.current.onAcceptEmpty(value, fieldId);
 
             const parsed = Number(value);
             if (value.trim() === "" || Number.isNaN(parsed)) {
-                clearDraft(); // clear draft and preview when field is emptied
+                clearDraft(); // field emptied
                 return;
             }
 
@@ -249,8 +235,7 @@ export function PairedFieldRow({
                     pitchRatio >= 1;
                 if (!geometryReady) return;
 
-                // useLivePreview already debounces – no extra debounce
-                // required.
+                // useLivePreview already debounces.
                 requestPreview({
                     OTLtoShell: OTLToShell,
                     tubeOD,
@@ -285,16 +270,27 @@ export function PairedFieldRow({
 
     const rowHint = row.find((cfg) => cfg.rowHint)?.rowHint;
 
+    // Shell ID's physical minimum is tubeOD + OTLtoShell; falls back to the
+    // static "> 0" config until both are known.
+    const shellIDMinReady =
+        utils.isNumber(fieldValues.tubeOD) && utils.isNumber(fieldValues.OTLtoShell);
+    const shellIDMin = shellIDMinReady
+        ? utils.round((fieldValues.tubeOD as number) + (fieldValues.OTLtoShell as number), 2)
+        : undefined;
+
     const fields = row.map((cfg, i) => {
         const isPinned = hasLivePreview && pinnedField?.id === cfg.id;
         let fieldValue = fieldValues[cfg.id];
         let isPreview = false;
         let placeholder = cfg.placeholder;
+        const isShellIDField = cfg.id === "shellID";
+        const fieldMin = isShellIDField && shellIDMinReady ? shellIDMin : cfg.min;
+        // Inclusive: the computed minimum is itself achievable.
+        const fieldMinExclusive = isShellIDField && shellIDMinReady ? false : cfg.minExclusive;
 
         if (hasLivePreview && fieldValue === undefined) {
             if (isPinned) {
-                // Frozen at focus time; the DOM (read on blur) holds whatever
-                // the user actually types, independent of this prop.
+                // Frozen at focus time; DOM (read on blur) holds the real typed value.
                 fieldValue = pinnedField!.value;
                 isPreview = true;
             } else {
@@ -311,11 +307,8 @@ export function PairedFieldRow({
                 }
             }
         } else if (hasLivePreview && cfg.id === previewTargetId) {
-            // Committed but still the dependent side of the pair (e.g. once
-            // tubeClearance/pitchRatio mutually derive each other on blur, both
-            // hold real numbers). Stays muted so the muted/valid contrast keeps
-            // showing which field is driving the pair versus which one is
-            // computed from it.
+            // Committed but still the dependent side of the pair – stays muted
+            // to show which field is driving vs. computed.
             isPreview = true;
         }
 
@@ -324,6 +317,8 @@ export function PairedFieldRow({
                 key={cfg.id}
                 {...cfg}
                 placeholder={placeholder}
+                min={fieldMin}
+                minExclusive={fieldMinExclusive}
                 value={fieldValue}
                 isPreview={isPreview}
                 pairedValue={cfg.pairedWith ? fieldValues[cfg.pairedWith] : undefined}

--- a/src/components/TubeSheetDataTable.tsx
+++ b/src/components/TubeSheetDataTable.tsx
@@ -3,7 +3,7 @@ import { ITubeSheetData, getEffectiveShellID } from "../plugins/tubesheet-layout
 import { utils } from "../utils/";
 
 export interface TubeSheetDataTableProps {
-    data: (ITubeSheetData & { shellID?: number; numTubes?: number }) | null;
+    data: (ITubeSheetData & { numTubes?: number }) | null;
     layoutLabel: string;
     requestedTubes?: number;
     visible: boolean;

--- a/src/constants/layoutOptionRows.ts
+++ b/src/constants/layoutOptionRows.ts
@@ -1,4 +1,5 @@
 import type { LayoutResults } from "../hooks/useTubeSheetWorker";
+import { TUBE_SHEET_LAYOUTS, type TubeSheetLayout } from "../plugins/tubesheet-layout-generator";
 
 // Layout options for displaying min ID and tube counts.
 export interface LayoutOptionRow {
@@ -9,10 +10,15 @@ export interface LayoutOptionRow {
     required?: boolean;
 }
 
-export const layoutOptionRows: LayoutOptionRow[] = [
-    { key: 30, id: "30deg", label: "30°", value: "30", required: true },
-    { key: 45, id: "45deg", label: "45°", value: "45" },
-    { key: 60, id: "60deg", label: "60°", value: "60" },
-    { key: 90, id: "90deg", label: "90°", value: "90" },
-    { key: "radial", id: "radial", label: "Radial", value: "0" },
-];
+const layoutOptionMeta: Record<TubeSheetLayout, Omit<LayoutOptionRow, "key">> = {
+    30: { id: "30deg", label: "30°", value: "30", required: true },
+    45: { id: "45deg", label: "45°", value: "45" },
+    60: { id: "60deg", label: "60°", value: "60" },
+    90: { id: "90deg", label: "90°", value: "90" },
+    radial: { id: "radial", label: "Radial", value: "0" },
+};
+
+export const layoutOptionRows: LayoutOptionRow[] = TUBE_SHEET_LAYOUTS.map((key) => ({
+    key,
+    ...layoutOptionMeta[key],
+}));

--- a/src/constants/numericFieldConfigs.ts
+++ b/src/constants/numericFieldConfigs.ts
@@ -1,4 +1,6 @@
 import type { NumericFieldProps } from "../components/NumericField";
+import type { PairPreviewContext } from "./pairPreviewConfigs";
+import { utils } from "../utils";
 
 export type NumericFieldConfig = Omit<NumericFieldProps, "value" | "pairedValue"> & {
     // Fields sharing the same "row" id are rendered side-by-side as a pair.
@@ -11,6 +13,9 @@ export type NumericFieldConfig = Omit<NumericFieldProps, "value" | "pairedValue"
     // Fields sharing the same "group" label are rendered together inside one
     // titled card, so related inputs read as a set rather than a flat list.
     group?: string;
+    // Overrides the static min/minExclusive once enough sibling values are
+    // known to compute a tighter, physically-derived minimum.
+    dynamicMin?: (ctx: PairPreviewContext) => { min: number; minExclusive: boolean } | undefined;
 };
 
 export const numericFieldConfigs: NumericFieldConfig[] = [
@@ -42,6 +47,11 @@ export const numericFieldConfigs: NumericFieldConfig[] = [
         pairedWith: "minTubes",
         pairedLabel: "Min # of tubes",
         group: "Design Constraint",
+        // Physical minimum is tubeOD + OTLtoShell once both are known.
+        dynamicMin: (ctx) =>
+            utils.isNumber(ctx.tubeOD) && utils.isNumber(ctx.OTLtoShell)
+                ? { min: utils.round(ctx.tubeOD + ctx.OTLtoShell, 2), minExclusive: false }
+                : undefined,
     },
     {
         id: "tubeOD",

--- a/src/constants/pairPreviewConfigs.ts
+++ b/src/constants/pairPreviewConfigs.ts
@@ -1,0 +1,87 @@
+import { utils } from "../utils";
+import type { LivePreviewRequest, LivePreviewResult } from "../hooks/useLivePreview";
+
+// Bag of current field values (plus layoutOption) previews are computed from.
+export type PairPreviewContext = Record<string, number | undefined>;
+
+// Last committed calculation result; fallback for the worker-driven size row.
+export interface CommittedSizeResult {
+    minID: number | null;
+    numTubes: number | null;
+}
+
+// Dependent value needs the tubesheet worker (e.g. minTubes <-> shellID has no closed-form inverse).
+export interface WorkerPairPreviewConfig {
+    kind: "worker";
+    isReady: (ctx: PairPreviewContext) => boolean;
+    buildRequest: (
+        fieldId: string,
+        parsedValue: number,
+        ctx: PairPreviewContext,
+    ) => LivePreviewRequest;
+    extractResult: (fieldId: string, result: LivePreviewResult | null) => number | undefined;
+    fallbackFromCommitted: (
+        fieldId: string,
+        ctx: PairPreviewContext,
+        committedResult: CommittedSizeResult | null | undefined,
+    ) => number | undefined;
+}
+
+// Dependent value is a pure synchronous formula (e.g. tubeClearance <-> pitchRatio via tubeOD).
+export interface FormulaPairPreviewConfig {
+    kind: "formula";
+    compute: (fieldId: string, parsedValue: number, ctx: PairPreviewContext) => number | undefined;
+}
+
+export type PairPreviewConfig = WorkerPairPreviewConfig | FormulaPairPreviewConfig;
+
+// Keyed by NumericFieldConfig.row. Rows absent here have no live preview.
+export const pairPreviewConfigs: Record<string, PairPreviewConfig> = {
+    "minTubes-shellID": {
+        kind: "worker",
+        isReady: (ctx) =>
+            utils.isNumber(ctx.OTLtoShell) &&
+            (ctx.OTLtoShell as number) >= 0 &&
+            utils.isNumber(ctx.tubeOD) &&
+            (ctx.tubeOD as number) > 0 &&
+            utils.isNumber(ctx.pitchRatio) &&
+            (ctx.pitchRatio as number) >= 1,
+        buildRequest: (fieldId, parsedValue, ctx) => ({
+            OTLtoShell: ctx.OTLtoShell as number,
+            tubeOD: ctx.tubeOD as number,
+            pitchRatio: ctx.pitchRatio as number,
+            layoutOption: utils.isNumber(ctx.layoutOption) ? (ctx.layoutOption as number) : 30,
+            minTubes: fieldId === "minTubes" ? parsedValue : undefined,
+            shellID: fieldId === "shellID" ? parsedValue : undefined,
+        }),
+        extractResult: (fieldId, result) => {
+            if (fieldId === "shellID") return result?.shellID;
+            if (fieldId === "minTubes") return result?.numTubes;
+            return undefined;
+        },
+        fallbackFromCommitted: (fieldId, ctx, committedResult) => {
+            if (
+                fieldId === "shellID" &&
+                utils.isNumber(ctx.minTubes) &&
+                utils.isNumber(committedResult?.minID)
+            ) {
+                return committedResult!.minID as number;
+            }
+            if (
+                fieldId === "minTubes" &&
+                utils.isNumber(ctx.shellID) &&
+                utils.isNumber(committedResult?.numTubes)
+            ) {
+                return committedResult!.numTubes as number;
+            }
+            return undefined;
+        },
+    },
+    "clearance-pitch": {
+        kind: "formula",
+        compute: (fieldId, parsedValue, ctx) =>
+            fieldId === "tubeClearance"
+                ? utils.pitchRatioFromClearance(ctx.tubeOD, parsedValue)
+                : utils.clearanceFromPitchRatio(ctx.tubeOD, parsedValue),
+    },
+};

--- a/src/hooks/useLivePreview.test.ts
+++ b/src/hooks/useLivePreview.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useLivePreview } from "./useLivePreview";
+
+describe("useLivePreview", () => {
+    it("keeps showing a ready result instead of reverting to null after the safety timeout window", async () => {
+        vi.useFakeTimers();
+
+        // Worker responds almost immediately (fast, successful response).
+        const requestSingle = vi.fn((_payload, callback) => {
+            setTimeout(() => callback({ numTubes: 0, shellID: 20 }), 10);
+            return 1;
+        });
+
+        const { result } = renderHook(() => useLivePreview(requestSingle as never));
+
+        act(() => {
+            result.current.request({
+                OTLtoShell: 10,
+                tubeOD: 25,
+                pitchRatio: 1.2,
+                layoutOption: 30,
+                shellID: 20,
+            });
+        });
+
+        // Advance past the debounce (350ms) + worker response (10ms).
+        await act(async () => {
+            vi.advanceTimersByTime(400);
+        });
+
+        expect(result.current.status).toBe("ready");
+        expect(result.current.result?.numTubes).toBe(0);
+
+        // Advance past the 1500ms safety timeout window (anchored to when the
+        // debounce fired), well after the response already landed.
+        await act(async () => {
+            vi.advanceTimersByTime(1500);
+        });
+
+        expect(result.current.status).toBe("ready");
+        expect(result.current.result?.numTubes).toBe(0);
+
+        vi.useRealTimers();
+    });
+
+    it("still marks the preview unavailable if the worker never responds", async () => {
+        vi.useFakeTimers();
+
+        const requestSingle = vi.fn(() => 1); // never calls back
+
+        const { result } = renderHook(() => useLivePreview(requestSingle as never));
+
+        act(() => {
+            result.current.request({
+                OTLtoShell: 10,
+                tubeOD: 25,
+                pitchRatio: 1.2,
+                layoutOption: 30,
+                shellID: 20,
+            });
+        });
+
+        await act(async () => {
+            vi.advanceTimersByTime(350 + 1500 + 1);
+        });
+
+        expect(result.current.status).toBe("unavailable");
+        expect(result.current.result).toBeNull();
+
+        vi.useRealTimers();
+    });
+});

--- a/src/hooks/useLivePreview.ts
+++ b/src/hooks/useLivePreview.ts
@@ -86,6 +86,13 @@ export function useLivePreview(
                     },
                     (response) => {
                         if (seq !== seqRef.current) return;
+                        // A response landed, so the safety timeout below no
+                        // longer applies — without this it would still fire
+                        // later and wrongly revert this result to null.
+                        if (timeoutRef.current) {
+                            clearTimeout(timeoutRef.current);
+                            timeoutRef.current = null;
+                        }
                         setResult({
                             shellID: response?.shellID ?? response?.minID ?? undefined,
                             numTubes: response?.numTubes ?? undefined,

--- a/src/hooks/useTubeSheetWorker.ts
+++ b/src/hooks/useTubeSheetWorker.ts
@@ -6,7 +6,7 @@ export type LayoutResults = Record<
     TubeSheetLayout,
     (ITubeSheetData & { preferred: boolean }) | null
 >;
-export type SingleResultPayload = (ITubeSheetData & { shellID?: number; numTubes?: number }) | null;
+export type SingleResultPayload = (ITubeSheetData & { numTubes?: number }) | null;
 
 const emptyLayoutResults: LayoutResults = Object.fromEntries(
     TUBE_SHEET_LAYOUTS.map((layout) => [layout, null]),

--- a/src/hooks/useTubeSheetWorker.ts
+++ b/src/hooks/useTubeSheetWorker.ts
@@ -1,23 +1,16 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { generateTubeSheetSVG, ITubeSheetData } from "../plugins/tubesheet-layout-generator";
+import { TUBE_SHEET_LAYOUTS, type TubeSheetLayout } from "../plugins/tubesheet-layout-generator";
 
-export type LayoutResults = {
-    30: (ITubeSheetData & { preferred: boolean }) | null;
-    45: (ITubeSheetData & { preferred: boolean }) | null;
-    60: (ITubeSheetData & { preferred: boolean }) | null;
-    90: (ITubeSheetData & { preferred: boolean }) | null;
-    radial: (ITubeSheetData & { preferred: boolean }) | null;
-};
-
+export type LayoutResults = Record<
+    TubeSheetLayout,
+    (ITubeSheetData & { preferred: boolean }) | null
+>;
 export type SingleResultPayload = (ITubeSheetData & { shellID?: number; numTubes?: number }) | null;
 
-const emptyLayoutResults: LayoutResults = {
-    "30": null,
-    "45": null,
-    "60": null,
-    "90": null,
-    radial: null,
-};
+const emptyLayoutResults: LayoutResults = Object.fromEntries(
+    TUBE_SHEET_LAYOUTS.map((layout) => [layout, null]),
+) as LayoutResults;
 
 // Loading badge is debounced so brief calculations don't cause a flash
 // and is held visible for a minimum duration once shown.

--- a/src/index.css
+++ b/src/index.css
@@ -45,6 +45,8 @@
   --greenline-light: hsl(135, 74%, 42%);
   --greenline-glow-light: hsl(135, 74%, 42%, 20%);
   --preferred-light: hsl(214, 68%, 42%);
+  --preferred-badge-light: hsl(36, 95%, 32%);
+  --preferred-badge-tint-light: hsl(36, 95%, 42%);
   --box-shadow-light-1: hsla(0, 0%, 0%, 0.3);
   --box-shadow-light-2: hsla(0, 0%, 0%, 0.1);
 
@@ -70,6 +72,8 @@
   --greenline-dark: hsl(135, 84%, 66%);
   --greenline-glow-dark: hsl(135, 84%, 66%, 20%);
   --preferred-dark: hsl(212, 84%, 76%);
+  --preferred-badge-dark: hsl(38, 90%, 66%);
+  --preferred-badge-tint-dark: hsl(38, 90%, 86%);
   --box-shadow-dark-1: hsla(0, 0%, 0%, 0.7);
   --box-shadow-dark-2: hsla(0, 0%, 0%, 0.5);
 
@@ -95,6 +99,8 @@
   --greenline: var(--greenline-light);
   --greenline-glow: var(--greenline-glow-light);
   --preferred: var(--preferred-light);
+  --preferred-badge: var(--preferred-badge-light);
+  --preferred-badge-tint: var(--preferred-badge-tint-light);
   --box-shadow-1: var(--box-shadow-light-1);
   --box-shadow-2: var(--box-shadow-light-2);
 
@@ -130,6 +136,8 @@
   --greenline: var(--greenline-dark);
   --greenline-glow: var(--greenline-glow-dark);
   --preferred: var(--preferred-dark);
+  --preferred-badge: var(--preferred-badge-dark);
+  --preferred-badge-tint: var(--preferred-badge-tint-dark);
   --box-shadow-1: var(--box-shadow-dark-1);
   --box-shadow-2: var(--box-shadow-dark-2);
 }
@@ -680,8 +688,7 @@ input[type="text"].field-preview:focus {
 
 /* Selected/preferred rows draw their border and ring above their
    neighbors', instead of a neighbor's plain divider painting over them. */
-.layout-row:has(input:checked),
-.layout-row.preferred {
+.layout-row:has(input:checked) {
   z-index: 1;
 }
 
@@ -689,16 +696,20 @@ input[type="text"].field-preview:focus {
   background-color: var(--input-readonly-background);
 }
 
-.layout-row.preferred {
-  z-index: 4;
-  box-shadow: 0 0 0 2px var(--preferred);
+.layout-row:hover .row-badge {
+  color: var(--preferred-badge-tint);
 }
 
 .layout-row .row-badge {
   display: inline-flex;
+
   margin-left: 4px;
-  color: var(--preferred);
-  opacity: 0.55;
+
+  color: var(--preferred-badge);
+
+  opacity: 1;
+
+  transition: color var(--transition);
 }
 
 .layout-row .row-badge svg {

--- a/src/index.css
+++ b/src/index.css
@@ -797,7 +797,7 @@ input[type="text"].field-preview:focus {
 
   font-family: var(--font-mono);
   font-size: 14px;
-  font-weight: 600;
+  font-weight: 700;
   color: var(--ink);
   text-align: center;
 }

--- a/src/plugins/tubesheet-layout-generator.test.ts
+++ b/src/plugins/tubesheet-layout-generator.test.ts
@@ -130,6 +130,20 @@ describe("TubeSheet — regression: findMinID hang on sparse tube fields", () =>
     });
 });
 
+describe("TubeSheet — minTubes/shellID getters when unset", () => {
+    it("returns undefined for shellID when constructed via minTubes", () => {
+        const ts = new TubeSheet(OTL_CLEARANCE, TUBE_OD, PITCH_RATIO, 30, 50);
+        expect(ts.shellID).toBeUndefined();
+        expect(ts.minTubes).toBe(50);
+    });
+
+    it("returns undefined for minTubes when constructed via shellID", () => {
+        const ts = new TubeSheet(OTL_CLEARANCE, TUBE_OD, PITCH_RATIO, 30, undefined, 500);
+        expect(ts.minTubes).toBeUndefined();
+        expect(ts.shellID).toBe(500);
+    });
+});
+
 describe("getEffectiveShellID", () => {
     it("returns shellID when shellID is explicitly set", () => {
         expect(
@@ -147,7 +161,7 @@ describe("getEffectiveShellID", () => {
             getEffectiveShellID({
                 tubeField: [{ x: 0, y: 0 }],
                 OTL: 10,
-                shellID: undefined as unknown as number,
+                shellID: undefined,
                 minID: 300,
             }),
         ).toBe(300);
@@ -158,7 +172,18 @@ describe("getEffectiveShellID", () => {
             getEffectiveShellID({
                 tubeField: null,
                 OTL: null,
-                shellID: undefined as unknown as number,
+                shellID: undefined,
+                minID: null,
+            }),
+        ).toBe(0);
+    });
+
+    it("returns 0, not undefined, when neither shellID nor minID is usable", () => {
+        expect(
+            getEffectiveShellID({
+                tubeField: [{ x: 0, y: 0 }],
+                OTL: 10,
+                shellID: undefined,
                 minID: null,
             }),
         ).toBe(0);

--- a/src/plugins/tubesheet-layout-generator.test.ts
+++ b/src/plugins/tubesheet-layout-generator.test.ts
@@ -96,6 +96,40 @@ describe("TubeSheet — edge cases", () => {
     });
 });
 
+describe("TubeSheet — regression: findMinID hang on sparse tube fields", () => {
+    // Guards against findMinID's upper-bound search hanging when its initial
+    // diameter guess yields zero tubes (large tubeOD/pitch relative to the
+    // available OTL). Vitest's default per-test timeout also catches a
+    // regression here; the assertions confirm the correct output values.
+    const OTL_CLEARANCE_SPARSE = 150;
+    const TUBE_OD_SPARSE = 90.53;
+    const SHELL_ID_SPARSE = 400;
+
+    const expected: Record<string, { numTubes: number; minID: number; OTL: number }> = {
+        "30": { numTubes: 2, minID: 353.6925, OTL: 203.6925 },
+        "45": { numTubes: 1, minID: 240.53, OTL: 90.53 },
+        "60": { numTubes: 2, minID: 353.6925, OTL: 203.6925 },
+        "90": { numTubes: 2, minID: 353.6925, OTL: 203.6925 },
+        radial: { numTubes: 3, minID: 371.198799674342, OTL: 221.19879967435 },
+    };
+
+    it.each(LAYOUTS)("resolves without hanging for layout %s", (layout) => {
+        const ts = new TubeSheet(
+            OTL_CLEARANCE_SPARSE,
+            TUBE_OD_SPARSE,
+            PITCH_RATIO,
+            layout,
+            undefined,
+            SHELL_ID_SPARSE,
+        );
+        const ref = expected[String(layout)];
+
+        expect(ts.numTubes).toBe(ref.numTubes);
+        expect(ts.minID).toBeCloseTo(ref.minID, 6);
+        expect(ts.OTL).toBeCloseTo(ref.OTL, 6);
+    });
+});
+
 describe("getEffectiveShellID", () => {
     it("returns shellID when shellID is explicitly set", () => {
         expect(

--- a/src/plugins/tubesheet-layout-generator.ts
+++ b/src/plugins/tubesheet-layout-generator.ts
@@ -12,7 +12,7 @@ export type TubeSheetLayout = (typeof TUBE_SHEET_LAYOUTS)[number];
 export interface ITubeSheetData {
     tubeField: TubeField | null;
     OTL: number | null;
-    shellID: number;
+    shellID?: number;
     minID: number | null;
     tubeOD: number;
     pitchRatio: number;
@@ -106,16 +106,16 @@ export class TubeSheet {
         this._minTubes = x;
         this.updateGeneratedProps();
     }
-    get minTubes() {
-        return this._minTubes as number;
+    get minTubes(): number | undefined {
+        return this._minTubes;
     }
 
     set shellID(x: number) {
         this._shellID = x;
         this.updateGeneratedProps();
     }
-    get shellID() {
-        return this._shellID as number;
+    get shellID(): number | undefined {
+        return this._shellID;
     }
 
     get tubeField() {
@@ -1089,8 +1089,9 @@ export const DRAWING_SAFE_CONTENT_RADIUS_FRACTION = 0.5 / (1 + VIEWBOX_PADDING_A
  * The TubeSheetData object.
  * @returns {number}
  * The effective shell ID. Returns 0 if both `ts.tubeField` and `ts.OTL` are
- * null. If `ts.shellID` is defined or `ts.minID` is not null, undefined, or 0,
- * returns `ts.shellID`. Otherwise, returns `ts.minID`.
+ * null. If `ts.shellID` is defined and non-zero, or `ts.minID` is null, 0, or
+ * NaN, returns `ts.shellID` (or 0 if `ts.shellID` is also unusable).
+ * Otherwise, returns `ts.minID`.
  */
 export const getEffectiveShellID = (
     ts: Pick<ITubeSheetData, "tubeField" | "OTL" | "shellID" | "minID">,
@@ -1100,10 +1101,11 @@ export const getEffectiveShellID = (
     }
 
     if (ts.shellID || ts.minID === null || ts.minID === 0 || isNaN(ts.minID)) {
-        return ts.shellID;
+        // ts.shellID may be undefined here if minID is also unusable.
+        return ts.shellID ?? 0;
     }
 
-    if (ts.shellID === 0 || isNaN(ts.shellID)) {
+    if (ts.shellID === undefined || ts.shellID === 0 || isNaN(ts.shellID)) {
         return ts.minID;
     }
 

--- a/src/plugins/tubesheet-layout-generator.ts
+++ b/src/plugins/tubesheet-layout-generator.ts
@@ -6,7 +6,8 @@ export interface Tube {
     y: number;
 }
 export type TubeField = Array<Tube>;
-export type TubeSheetLayout = 30 | 45 | 60 | 90 | "radial";
+export const TUBE_SHEET_LAYOUTS = [30, 45, 60, 90, "radial"] as const;
+export type TubeSheetLayout = (typeof TUBE_SHEET_LAYOUTS)[number];
 
 export interface ITubeSheetData {
     tubeField: TubeField | null;

--- a/src/plugins/tubesheet-layout-generator.ts
+++ b/src/plugins/tubesheet-layout-generator.ts
@@ -603,6 +603,7 @@ const tubeFieldOTL = (
             }
             return OTL;
         }
+        return null;
     } catch {
         return null;
     }
@@ -979,7 +980,16 @@ const findMinID = memoize(
 
                     if (!haveUpperBound) {
                         let D_grow = haveLowerBound ? D_lowerBound : D_old;
-                        while (true) {
+                        // Bounded, with a finiteness check: an unbounded loop
+                        // here can hang forever if D_grow ever became NaN.
+                        const GROW_MAX_ITERATIONS = 1000;
+                        let growIterations = 0;
+                        while (growIterations < GROW_MAX_ITERATIONS) {
+                            if (!Number.isFinite(D_grow) || D_grow <= 0) {
+                                throw new Error(
+                                    "findMinID: diameter guess became non-finite while searching for an upper bound.",
+                                );
+                            }
                             D_grow = D_grow * BETA;
                             const numTubesUpper = tubeCount(
                                 D_grow,
@@ -1004,6 +1014,12 @@ const findMinID = memoize(
                                 haveUpperBound = true;
                                 break;
                             }
+                            growIterations++;
+                        }
+                        if (!haveUpperBound) {
+                            throw new Error(
+                                "findMinID: unable to bound a valid diameter within the iteration limit.",
+                            );
                         }
                     }
 

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -4,6 +4,7 @@ import {
     getEffectiveShellID,
     type TubeSheetLayout,
 } from "../plugins/tubesheet-layout-generator";
+import { utils } from "./index";
 
 // Fixed set of realistic inputs reused across cases.
 const OTL_CLEARANCE = 6.35;
@@ -97,6 +98,24 @@ describe("TubeSheet — edge cases", () => {
         expect(() => new TubeSheet(OTL_CLEARANCE, TUBE_OD, 0.5, 30, undefined, 500)).toThrow(
             /pitch ratio/i,
         );
+    });
+});
+
+describe("utils — comma-formatted number round-trip", () => {
+    // numberWithCommas adds a separator every 3 digits, so values >= 1e6 get
+    // more than one comma; isNumber/stringToNumber must strip all of them.
+    it.each([
+        ["1,234", 1234],
+        ["1,234,567", 1234567],
+        ["12,345,678", 12345678],
+    ])("parses %s back to %d", (formatted, expected) => {
+        expect(utils.isNumber(formatted)).toBe(true);
+        expect(utils.stringToNumber(formatted)).toBe(expected);
+    });
+
+    it("round-trips numberWithCommas output through stringToNumber", () => {
+        const n = 12345678;
+        expect(utils.stringToNumber(utils.numberWithCommas(n))).toBe(n);
     });
 });
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -25,7 +25,7 @@ export const utils = {
     isNumber(x: unknown): x is number {
         return (
             (typeof x === "number" && x - x === 0) ||
-            (typeof x === "string" && Number.isFinite(+x.replace(",", "")) && x.trim() !== "")
+            (typeof x === "string" && Number.isFinite(+x.replaceAll(",", "")) && x.trim() !== "")
         );
     },
     // Shared with the tubeClearance/pitchRatio paired-field preview so the
@@ -37,7 +37,7 @@ export const utils = {
         return this.isNumber(tubeOD) ? (pitchRatio - 1) * tubeOD : undefined;
     },
     stringToNumber(x: string) {
-        return parseFloat(x.replace(",", ""));
+        return parseFloat(x.replaceAll(",", ""));
     },
     symlog(x: number, c: number = 1) {
         return Math.sign(x) * Math.log10(Math.abs(x) / c + 1);

--- a/src/workers/tubesheet.worker.test.ts
+++ b/src/workers/tubesheet.worker.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeAll } from "vitest";
+
+// Importing the worker module registers self.onmessage as a side effect.
+beforeAll(async () => {
+    await import("./tubesheet.worker");
+});
+
+const getHandler = () => self.onmessage as unknown as (e: MessageEvent) => void;
+
+describe("tubesheet.worker — unknown message type", () => {
+    it("replies with ERROR instead of hanging silently", () => {
+        const postMessageSpy = vi.spyOn(self, "postMessage").mockImplementation(() => {});
+
+        getHandler()({
+            data: { type: "BOGUS_TYPE", requestId: "req-1", payload: {} },
+        } as MessageEvent);
+
+        expect(postMessageSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: "ERROR",
+                requestId: "req-1",
+                requestType: "BOGUS_TYPE",
+                payload: expect.stringContaining("BOGUS_TYPE"),
+            }),
+        );
+
+        postMessageSpy.mockRestore();
+    });
+});
+
+describe("tubesheet.worker — known message types still work", () => {
+    it("responds to CALCULATE_SINGLE as before", () => {
+        const postMessageSpy = vi.spyOn(self, "postMessage").mockImplementation(() => {});
+
+        getHandler()({
+            data: {
+                type: "CALCULATE_SINGLE",
+                requestId: "req-2",
+                payload: {
+                    OTLtoShell: 6.35,
+                    tubeOD: 19.05,
+                    pitchRatio: 1.25,
+                    layoutOption: 30,
+                    minTubes: 50,
+                },
+            },
+        } as MessageEvent);
+
+        expect(postMessageSpy).toHaveBeenCalledWith(
+            expect.objectContaining({ type: "SINGLE_RESULT", requestId: "req-2" }),
+        );
+
+        postMessageSpy.mockRestore();
+    });
+});

--- a/src/workers/tubesheet.worker.test.ts
+++ b/src/workers/tubesheet.worker.test.ts
@@ -52,4 +52,35 @@ describe("tubesheet.worker — known message types still work", () => {
 
         postMessageSpy.mockRestore();
     });
+
+    it("responds to CALCULATE_ALL with results keyed directly by layout", () => {
+        const postMessageSpy = vi.spyOn(self, "postMessage").mockImplementation(() => {});
+
+        getHandler()({
+            data: {
+                type: "CALCULATE_ALL",
+                requestId: "req-3",
+                payload: {
+                    OTLtoShell: 6.35,
+                    tubeOD: 19.05,
+                    pitchRatio: 1.25,
+                    minTubes: 50,
+                },
+            },
+        } as MessageEvent);
+
+        const sent = postMessageSpy.mock.calls[0][0] as {
+            type: string;
+            requestId: string;
+            payload: Record<string, unknown>;
+        };
+
+        expect(sent.type).toBe("ALL_RESULTS");
+        // payload should be keyed directly by layout (e.g. payload[30]),
+        // not wrapped in an extra { payload: {...} } level.
+        expect(sent.payload).toHaveProperty("30");
+        expect(sent.payload).toHaveProperty("radial");
+
+        postMessageSpy.mockRestore();
+    });
 });

--- a/src/workers/tubesheet.worker.ts
+++ b/src/workers/tubesheet.worker.ts
@@ -47,11 +47,9 @@ self.onmessage = (event: MessageEvent) => {
             self.postMessage({
                 type: "ALL_RESULTS",
                 requestId,
-                payload: {
-                    payload: Object.fromEntries(
-                        TUBE_SHEET_LAYOUTS.map((l) => [l, markPreferred(tubeSheets[l])]),
-                    ),
-                },
+                payload: Object.fromEntries(
+                    TUBE_SHEET_LAYOUTS.map((l) => [l, markPreferred(tubeSheets[l])]),
+                ),
             });
         }
 

--- a/src/workers/tubesheet.worker.ts
+++ b/src/workers/tubesheet.worker.ts
@@ -4,6 +4,10 @@ self.onmessage = (event: MessageEvent) => {
     const { type, requestId, payload } = event.data;
 
     try {
+        if (type !== "CALCULATE_ALL" && type !== "CALCULATE_SINGLE") {
+            throw new Error(`Unknown message type: ${type}`);
+        }
+
         if (type === "CALCULATE_ALL") {
             const { OTLtoShell, tubeOD, pitchRatio, minTubes, shellID } = payload;
 

--- a/src/workers/tubesheet.worker.ts
+++ b/src/workers/tubesheet.worker.ts
@@ -20,13 +20,27 @@ self.onmessage = (event: MessageEvent) => {
                 shellID,
             );
 
-            const minID = Math.min(
-                _30.minID ?? Infinity,
-                _45.minID ?? Infinity,
-                _60.minID ?? Infinity,
-                _90.minID ?? Infinity,
-                radial.minID ?? Infinity,
-            );
+            // Preferred layout: max tubes when shellID is pinned, else min shell ID.
+            const isShellIDPinned = shellID !== undefined && shellID !== null;
+
+            const bestValue = isShellIDPinned
+                ? Math.max(
+                      _30.numTubes ?? -Infinity,
+                      _45.numTubes ?? -Infinity,
+                      _60.numTubes ?? -Infinity,
+                      _90.numTubes ?? -Infinity,
+                      radial.numTubes ?? -Infinity,
+                  )
+                : Math.min(
+                      _30.minID ?? Infinity,
+                      _45.minID ?? Infinity,
+                      _60.minID ?? Infinity,
+                      _90.minID ?? Infinity,
+                      radial.minID ?? Infinity,
+                  );
+
+            const isPreferred = (ts: TubeSheet) =>
+                isShellIDPinned ? ts.numTubes === bestValue : ts.minID === bestValue;
 
             const markPreferred = (ts: TubeSheet, preferred: boolean) => ({
                 minID: ts.minID,
@@ -45,11 +59,11 @@ self.onmessage = (event: MessageEvent) => {
                 type: "ALL_RESULTS",
                 requestId,
                 payload: {
-                    30: markPreferred(_30, _30.minID === minID),
-                    45: markPreferred(_45, _45.minID === minID),
-                    60: markPreferred(_60, _60.minID === minID),
-                    90: markPreferred(_90, _90.minID === minID),
-                    radial: markPreferred(radial, radial.minID === minID),
+                    30: markPreferred(_30, isPreferred(_30)),
+                    45: markPreferred(_45, isPreferred(_45)),
+                    60: markPreferred(_60, isPreferred(_60)),
+                    90: markPreferred(_90, isPreferred(_90)),
+                    radial: markPreferred(radial, isPreferred(radial)),
                 },
             });
         }

--- a/src/workers/tubesheet.worker.ts
+++ b/src/workers/tubesheet.worker.ts
@@ -1,4 +1,8 @@
-import { TubeSheet } from "../plugins/tubesheet-layout-generator";
+import {
+    TubeSheet,
+    TUBE_SHEET_LAYOUTS,
+    type TubeSheetLayout,
+} from "../plugins/tubesheet-layout-generator";
 
 self.onmessage = (event: MessageEvent) => {
     const { type, requestId, payload } = event.data;
@@ -11,42 +15,23 @@ self.onmessage = (event: MessageEvent) => {
         if (type === "CALCULATE_ALL") {
             const { OTLtoShell, tubeOD, pitchRatio, minTubes, shellID } = payload;
 
-            const _30 = new TubeSheet(OTLtoShell, tubeOD, pitchRatio, 30, minTubes, shellID);
-            const _45 = new TubeSheet(OTLtoShell, tubeOD, pitchRatio, 45, minTubes, shellID);
-            const _60 = new TubeSheet(OTLtoShell, tubeOD, pitchRatio, 60, minTubes, shellID);
-            const _90 = new TubeSheet(OTLtoShell, tubeOD, pitchRatio, 90, minTubes, shellID);
-            const radial = new TubeSheet(
-                OTLtoShell,
-                tubeOD,
-                pitchRatio,
-                "radial",
-                minTubes,
-                shellID,
-            );
+            const tubeSheets = Object.fromEntries(
+                TUBE_SHEET_LAYOUTS.map((layout) => [
+                    layout,
+                    new TubeSheet(OTLtoShell, tubeOD, pitchRatio, layout, minTubes, shellID),
+                ]),
+            ) as Record<TubeSheetLayout, TubeSheet>;
 
             // Preferred layout: max tubes when shellID is pinned, else min shell ID.
             const isShellIDPinned = shellID !== undefined && shellID !== null;
 
             const bestValue = isShellIDPinned
-                ? Math.max(
-                      _30.numTubes ?? -Infinity,
-                      _45.numTubes ?? -Infinity,
-                      _60.numTubes ?? -Infinity,
-                      _90.numTubes ?? -Infinity,
-                      radial.numTubes ?? -Infinity,
-                  )
-                : Math.min(
-                      _30.minID ?? Infinity,
-                      _45.minID ?? Infinity,
-                      _60.minID ?? Infinity,
-                      _90.minID ?? Infinity,
-                      radial.minID ?? Infinity,
-                  );
+                ? Math.max(...TUBE_SHEET_LAYOUTS.map((l) => tubeSheets[l].numTubes ?? -Infinity))
+                : Math.min(...TUBE_SHEET_LAYOUTS.map((l) => tubeSheets[l].minID ?? Infinity));
 
             const isPreferred = (ts: TubeSheet) =>
                 isShellIDPinned ? ts.numTubes === bestValue : ts.minID === bestValue;
-
-            const markPreferred = (ts: TubeSheet, preferred: boolean) => ({
+            const markPreferred = (ts: TubeSheet) => ({
                 minID: ts.minID,
                 numTubes: ts.numTubes,
                 OTL: ts.OTL,
@@ -55,7 +40,7 @@ self.onmessage = (event: MessageEvent) => {
                 tubeOD: ts.tubeOD,
                 pitchRatio: ts.pitchRatio,
                 shellID: ts.shellID,
-                preferred,
+                preferred: isPreferred(ts),
             });
 
             // Package data to send back (Workers cannot send class instances or DOM nodes)
@@ -63,11 +48,9 @@ self.onmessage = (event: MessageEvent) => {
                 type: "ALL_RESULTS",
                 requestId,
                 payload: {
-                    30: markPreferred(_30, isPreferred(_30)),
-                    45: markPreferred(_45, isPreferred(_45)),
-                    60: markPreferred(_60, isPreferred(_60)),
-                    90: markPreferred(_90, isPreferred(_90)),
-                    radial: markPreferred(radial, isPreferred(radial)),
+                    payload: Object.fromEntries(
+                        TUBE_SHEET_LAYOUTS.map((l) => [l, markPreferred(tubeSheets[l])]),
+                    ),
                 },
             });
         }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,8 +13,8 @@
         // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
         /* Language and Environment */
-        "target": "es2019"                                 /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
-        // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+        "target": "esnext"                                 /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+        // "lib": ["DOM", "DOM.Iterable", "ESNext"],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
         // "jsx": "preserve",                                /* Specify what JSX code is generated. */
         // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
         // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */


### PR DESCRIPTION
## Summary
Fixes several bugs in the paired-field live-preview system (shell ID / min tubes, clearance / pitch ratio) and adds Escape-to-cancel support, plus smaller correctness fixes in the layout generator and worker.

## Live preview & paired fields
- **Esc cancels an in-progress edit** instead of committing it. `NumericField` now remounts on Escape to discard uncommitted DOM text, and `PairedFieldRow` restores the row's preview/pin state to what it was before the field was focused.
- **Race condition fixed**: a late-arriving worker response no longer gets clobbered by the preview's safety timeout after the fact.
- **Preview now shows before the first commit** when a non-pinned field is focused — previously the preview only appeared after pinning had already occurred.
- **Stale preview after an invalid paired input** is now refreshed with the freshly computed value instead of showing the old committed one.
- Extracted the hardcoded per-row preview logic (size row vs. clearance/pitch row) out of `PairedFieldRow.tsx` into a new `pairPreviewConfigs.ts`, and moved input-type config into `numericFieldConfigs.ts`. `PairedFieldRow` now just looks up a row's config rather than branching on `isSizeRow`/`isClearancePitchRow`.
- Min-value validation for shell ID is now dynamic (`tubeOD + OTLtoShell`) instead of static, once both are known.
- Preview/dependent fields no longer show error styling, and no longer paint a false "preferred" outline via `:has()`/`.preferred` z-index conflicts (visual cleanup in `index.css`, plus `noselect` on preview text).

## Layout generator / worker
- Fixed a case where `findMinID`'s upper-bound search could hang forever if the initial diameter guess produced zero tubes — the loop is now bounded with a finite-value check and throws instead of spinning.
- Fixed the "preferred" layout selection to pick **max tubes** when shell ID is the pinned constraint, rather than always minimizing tube count.
- `shellID`/`minTubes` on `TubeSheet` are now typed as `number | undefined` instead of being force-cast, removing an unsafe cast that could hide `undefined` values.
- `TubeSheetLayout` now derives from a single `TUBE_SHEET_LAYOUTS` const array instead of a hand-maintained union, used consistently across the worker, hook, and layout rows.
- Worker rejects unknown message types instead of silently no-op'ing.
- Fixed regression in the `CALCULATE_ALL` worker path (from the preferred-layout refactor).
- Fixed OTL variable capitalization regression; `tubeFieldOTL` now explicitly returns `null` on its fallthrough path.

## Small fixes
- `NaN` result now renders as `—` instead of the literal text `NaN`.
- Numbers with more than one comma (e.g. `1,234,567`) are now stripped correctly (`replace` → `replaceAll`).
- `.gitignore` now ignores `*.zip`.

## Testing
Added/updated unit tests for: Escape-to-cancel (`NumericField.test.tsx`), NaN rendering (`LayoutOptionsList.test.tsx`), live preview race handling (`useLivePreview.test.ts`), paired-field behavior (`PairedFieldRow.test.tsx`), the worker (`tubesheet.worker.test.ts`), and the layout generator (`tubesheet-layout-generator.test.ts`).